### PR TITLE
createStrMapFromDictionary added

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,17 @@ const NumberSet = createSetFromArray(t.number, ordNumber)
 NumberSet.decode([1, 2, 3] // Set([1, 2, 3])
 ```
 
+### `createStrMapFromDictionary`
+
+```ts
+import * as t from 'io-ts';
+
+const NumberStrMap = createStrMapFromDictionary(t.number)
+NumberStrMap.decode({ someNumber: 42 }) // StrMap<number>({ someNumber: 42 })
+NumberStrMap.encode(new StrMap({ someNumber: 42 })) // { someNumber: 42 }
+
+```
+
 ## `JSON`
 
 ### `JSONFromString`

--- a/src/fp-ts/createStrMapFromDictionary.ts
+++ b/src/fp-ts/createStrMapFromDictionary.ts
@@ -1,0 +1,32 @@
+import { StrMap } from 'fp-ts/lib/StrMap'
+import * as t from 'io-ts'
+
+export class StrMapType<RT extends t.Any, A = any, O = A, I = t.mixed> extends t.Type<A, O, I> {
+  readonly _tag: 'StrMapType' = 'StrMapType'
+  constructor(
+    name: string,
+    is: StrMapType<RT, A, O, I>['is'],
+    validate: StrMapType<RT, A, O, I>['validate'],
+    serialize: StrMapType<RT, A, O, I>['encode'],
+    readonly type: RT
+  ) {
+    super(name, is, validate, serialize)
+  }
+}
+
+export const createStrMapFromDictionary = <RT extends t.Type<A, O>, A = any, O = A>(
+  type: RT,
+  name: string = `StrMap<${type.name}>`
+): StrMapType<RT, StrMap<t.TypeOf<RT>>, Record<string, t.OutputOf<RT>>, t.mixed> => {
+  const Dict = t.dictionary(t.string, type)
+  return new StrMapType(
+    name,
+    (m): m is StrMap<t.TypeOf<RT>> => m instanceof StrMap && Object.keys(m.value).every(key => type.is(m.value[key])),
+    (s, c) => {
+      const validation = Dict.validate(s, c)
+      return validation.isLeft() ? (validation as any) : t.success(new StrMap(validation.value))
+    },
+    a => Dict.encode(a.value),
+    type
+  )
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ export { createNonEmptyArrayFromArray } from './fp-ts/createNonEmptyArrayFromArr
 export { createOptionFromJSON } from './fp-ts/createOptionFromJSON'
 export { createOptionFromNullable } from './fp-ts/createOptionFromNullable'
 export { createSetFromArray } from './fp-ts/createSetFromArray'
+export { createStrMapFromDictionary } from './fp-ts/createStrMapFromDictionary'
 
 // JSON
 export { JSONFromString, JSONType } from './JSON/JSONFromString'

--- a/test/index.ts
+++ b/test/index.ts
@@ -16,6 +16,7 @@ import {
   createOptionFromNullable,
   createNonEmptyArrayFromArray,
   createSetFromArray,
+  createStrMapFromDictionary,
   fromNewtype,
   lensesFromProps,
   lensesFromInterface,
@@ -28,6 +29,7 @@ import { Newtype } from 'newtype-ts'
 import { Validation } from 'io-ts'
 import { NonEmptyArray } from 'fp-ts/lib/NonEmptyArray'
 import { ordNumber } from 'fp-ts/lib/Ord'
+import { StrMap } from 'fp-ts/lib/StrMap'
 
 describe('mapOutput', () => {
   it('should map the output of encode', () => {
@@ -139,6 +141,21 @@ describe('fp-ts', () => {
     assert.deepEqual(T.encode(new Set([1])), [1])
     assert.deepEqual(T.encode(new Set([])), [])
     assert.deepEqual(T.encode(new Set()), [])
+  })
+
+  it('createStrMapFromDictionary', () => {
+    const T = createStrMapFromDictionary(t.number)
+
+    assert.deepEqual(T.decode({}), right(new StrMap({})))
+    assert.deepEqual(T.decode({ foo: 42 }), right(new StrMap({ foo: 42 })))
+    assert.deepEqual(PathReporter.report(T.decode({ foo: 'not a number' })), [
+      'Invalid value "not a number" supplied to : StrMap<number>/foo: number'
+    ])
+    assert.deepEqual(T.encode(new StrMap({})), {})
+    assert.deepEqual(T.encode(new StrMap({ foo: 42 })), { foo: 42 })
+    assert.strictEqual(T.is(new StrMap({ foo: 42 })), true)
+    assert.strictEqual(T.is(new StrMap({ foo: 'not a number' })), false)
+    assert.strictEqual(T.is('not a strmap'), false)
   })
 })
 


### PR DESCRIPTION
This pull request adds `createStrMapFromDictionary` which allows the conversion and validation from an Plain JS Object to a `StrMap`.