### PR TITLE
Bug Fix: upstream inference bug using createOptionFromNullable in a nested runtime type, closes #67

### DIFF
--- a/dtslint/index.d.ts
+++ b/dtslint/index.d.ts
@@ -1,0 +1,1 @@
+// TypeScript Version: 2.3

--- a/dtslint/index.ts
+++ b/dtslint/index.ts
@@ -1,0 +1,15 @@
+import * as t from 'io-ts'
+import { createOptionFromNullable } from '../src'
+
+//
+// createOptionFromNullable
+//
+
+const T1 = createOptionFromNullable(t.string)
+type T1T1 = t.TypeOf<typeof T1> // $ExpectType Option<string>
+type T1T2 = t.OutputOf<typeof T1> // $ExpectType string | null
+const T2 = t.type({
+  a: createOptionFromNullable(t.string)
+})
+type T2T1 = t.TypeOf<typeof T2>['a'] // $ExpectType Option<string>
+type T2T2 = t.OutputOf<typeof T2>['a'] // $ExpectType string | null

--- a/dtslint/tsconfig.json
+++ b/dtslint/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "noEmit": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "noImplicitReturns": false,
+    "noUnusedLocals": false,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "target": "es5",
+    "lib": ["es2015"]
+  }
+}

--- a/dtslint/tslint.json
+++ b/dtslint/tslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "dtslint/dtslint.json",
+  "rules": {
+    "semicolon": false,
+    "array-type": false
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -6608,9 +6608,9 @@
       }
     },
     "typescript": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.6.tgz",
-      "integrity": "sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.3.tgz",
+      "integrity": "sha512-+81MUSyX+BaSo+u2RbozuQk/UWx6hfG0a5gHu4ANEM4sU96XbuIyAB+rWBW1u70c6a5QuZfuYICn3s2UjuHUpA==",
       "dev": true
     },
     "uglify-js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,12 @@
       "integrity": "sha1-mqvBNZed7TgzJXSfUIiUxmKUjIs=",
       "dev": true
     },
+    "@types/parsimmon": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@types/parsimmon/-/parsimmon-1.10.0.tgz",
+      "integrity": "sha512-bsTIJFVQv7jnvNiC42ld2pQW2KRI+pAG243L+iATvqzy3X6+NH1obz2itRKDZZ8VVhN3wjwYax/VBGCcXzgTqQ==",
+      "dev": true
+    },
     "abab": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
@@ -133,6 +139,12 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true
+    },
+    "any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8=",
       "dev": true
     },
     "anymatch": {
@@ -1239,6 +1251,12 @@
         "delayed-stream": "~1.0.0"
       }
     },
+    "commander": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
+      "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
+      "dev": true
+    },
     "compare-versions": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.3.0.tgz",
@@ -1477,6 +1495,14 @@
         }
       }
     },
+    "definitelytyped-header-parser": {
+      "version": "github:Microsoft/definitelytyped-header-parser#c79916047989994b21f3332771c6b97191c03d38",
+      "dev": true,
+      "requires": {
+        "@types/parsimmon": "1.10.0",
+        "parsimmon": "1.12.0"
+      }
+    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -1544,6 +1570,67 @@
       "dev": true,
       "requires": {
         "is-obj": "^1.0.0"
+      }
+    },
+    "dtslint": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/dtslint/-/dtslint-0.3.0.tgz",
+      "integrity": "sha512-3oWL8MD+2nKaxmNzrt8EAissP63hNSJ4OLr/itvNnPdAAl+7vxnjQ8p2Zdk0MNgdenqwk7GcaUDz7fQHaPgCyA==",
+      "dev": true,
+      "requires": {
+        "definitelytyped-header-parser": "github:Microsoft/definitelytyped-header-parser#c79916047989994b21f3332771c6b97191c03d38",
+        "fs-promise": "2.0.3",
+        "strip-json-comments": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+        "tslint": "5.11.0",
+        "typescript": "3.2.0-dev.20181027"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "supports-color": "5.4.0"
+          }
+        },
+        "tslint": {
+          "version": "5.11.0",
+          "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.11.0.tgz",
+          "integrity": "sha1-mPMMAurjzecAYgHkwzywi0hYHu0=",
+          "dev": true,
+          "requires": {
+            "babel-code-frame": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+            "builtin-modules": "1.1.1",
+            "chalk": "2.4.1",
+            "commander": "2.19.0",
+            "diff": "3.5.0",
+            "glob": "7.1.2",
+            "js-yaml": "3.12.0",
+            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
+            "semver": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+            "tslib": "1.9.3",
+            "tsutils": "2.29.0"
+          }
+        },
+        "typescript": {
+          "version": "3.2.0-dev.20181027",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.0-dev.20181027.tgz",
+          "integrity": "sha512-mRKqWa8rr7j40xa/7nSkhsa7jSwAoH1PlQInCDQ+G1UVUsMfA7vdSo4Qf/jq2/wd2wqnF3M4TSvQYiYU+52aFA==",
+          "dev": true
+        }
       }
     },
     "duplexer": {
@@ -1933,6 +2020,39 @@
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
         "universalify": "^0.1.0"
+      }
+    },
+    "fs-promise": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/fs-promise/-/fs-promise-2.0.3.tgz",
+      "integrity": "sha1-9k5PhUvPaJqovdy6JokW2z20aFQ=",
+      "dev": true,
+      "requires": {
+        "any-promise": "1.3.0",
+        "fs-extra": "2.1.2",
+        "mz": "2.7.0",
+        "thenify-all": "1.6.0"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz",
+          "integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+            "jsonfile": "2.4.0"
+          }
+        },
+        "jsonfile": {
+          "version": "2.4.0",
+          "resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+          "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+          }
+        }
       }
     },
     "fs.realpath": {
@@ -4290,6 +4410,17 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
+    "mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "requires": {
+        "any-promise": "1.3.0",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+        "thenify-all": "1.6.0"
+      }
+    },
     "nan": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
@@ -4661,6 +4792,12 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
       "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
+      "dev": true
+    },
+    "parsimmon": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/parsimmon/-/parsimmon-1.12.0.tgz",
+      "integrity": "sha512-uC/BjuSfb4jfaWajKCp1mVncXXq+V1twbcYChbTxN3GM7fn+8XoHwUdvUz+PTaFtDSCRQxU8+Rnh+iMhAkVwdw==",
       "dev": true
     },
     "pascalcase": {
@@ -6254,6 +6391,24 @@
         }
       }
     },
+    "thenify": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.0.tgz",
+      "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
+      "dev": true,
+      "requires": {
+        "any-promise": "1.3.0"
+      }
+    },
+    "thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
+      "dev": true,
+      "requires": {
+        "thenify": "3.3.0"
+      }
+    },
     "throat": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
@@ -6526,6 +6681,12 @@
         "strip-json-comments": "^2.0.0"
       }
     },
+    "tslib": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+      "dev": true
+    },
     "tslint": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/tslint/-/tslint-4.4.2.tgz",
@@ -6580,6 +6741,15 @@
       "dev": true,
       "requires": {
         "doctrine": "^0.7.2"
+      }
+    },
+    "tsutils": {
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
+      "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
+      "dev": true,
+      "requires": {
+        "tslib": "1.9.3"
       }
     },
     "tunnel-agent": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "ts-node": "3.2.1",
     "tslint": "4.4.2",
     "tslint-config-standard": "4.0.0",
-    "typescript": "^3.0.1"
+    "typescript": "^3.1.3"
   },
   "tags": [
     "io-ts",

--- a/package.json
+++ b/package.json
@@ -12,10 +12,11 @@
     "jest": "jest",
     "prettier": "prettier --no-semi --single-quote --print-width 120 --parser typescript --list-different \"{src,test}/**/*.ts\" || { echo \"Failure due to formatting, please run 'npm run fix-prettier' to fix this issue\"; exit 1; }",
     "fix-prettier": "prettier --no-semi --single-quote --print-width 120 --parser typescript --write \"{src,test}/**/*.ts\"",
-    "test": "npm run build && npm run lint && npm run prettier && npm run check-declarations && npm run jest",
+    "test": "npm run build && npm run lint && npm run dtslint && npm run prettier && npm run check-declarations && npm run jest",
     "clean": "rm -rf lib/*",
     "build": "npm run clean && tsc",
-    "check-declarations": "count=$(grep -R 'node_modules' ./lib | wc -l); exit $count"
+    "check-declarations": "count=$(grep -R 'node_modules' ./lib | wc -l); exit $count",
+    "dtslint": "dtslint dtslint"
   },
   "repository": {
     "type": "git",
@@ -36,6 +37,7 @@
   "devDependencies": {
     "@types/jest": "^22.2.2",
     "@types/node": "7.0.4",
+    "dtslint": "^0.3.0",
     "jest": "^22.4.3",
     "prettier": "^1.13.5",
     "ts-jest": "^22.4.2",

--- a/src/fp-ts/createOptionFromNullable.ts
+++ b/src/fp-ts/createOptionFromNullable.ts
@@ -14,10 +14,10 @@ export class OptionFromNullableType<RT extends t.Any, A = any, O = A, I = t.mixe
   }
 }
 
-export const createOptionFromNullable = <RT extends t.Type<A, O>, A = t.TypeOf<RT>, O = t.OutputOf<RT>>(
-  type: RT,
+export const createOptionFromNullable = <A, O>(
+  type: t.Type<A, O, t.mixed>,
   name: string = `Option<${type.name}>`
-): OptionFromNullableType<RT, Option<A>, O | null, t.mixed> => {
+): OptionFromNullableType<typeof type, Option<A>, O | null, t.mixed> => {
   const Nullable = t.union([type, t.null, t.undefined])
   return new OptionFromNullableType(
     name,


### PR DESCRIPTION
@sledorze what do you think about this pattern?

```ts
export const createOptionFromNullable = <A, O>(
  type: t.Type<A, O, t.mixed>,
  name: string = `Option<${type.name}>`
): OptionFromNullableType<typeof type, Option<A>, O | null, t.mixed>
```