### PR TITLE
export Codec types - fixes #77

### DIFF
--- a/src/JSON/JSONTypeRT.ts
+++ b/src/JSON/JSONTypeRT.ts
@@ -7,5 +7,5 @@ export type JSONType = null | string | number | boolean | JSONArray | JSONObject
 export interface JSONTypeC extends t.RecursiveType<t.Type<JSONType>> {}
 
 export const JSONTypeRT: JSONTypeC = t.recursion<JSONType>('JSONType', Self =>
-  t.union([t.null, t.string, t.number, t.boolean, t.array(Self), t.dictionary(t.string, Self)])
+  t.union([t.null, t.string, t.number, t.boolean, t.array(Self), t.record(t.string, Self)])
 )

--- a/src/fp-ts/createStrMapFromDictionary.ts
+++ b/src/fp-ts/createStrMapFromDictionary.ts
@@ -21,7 +21,7 @@ export const createStrMapFromDictionary = <C extends t.Mixed>(
   codec: C,
   name: string = `StrMap<${codec.name}>`
 ): StrMapC<C> => {
-  const Dict = t.dictionary(t.string, codec)
+  const Dict = t.record(t.string, codec)
   return new StrMapType(
     name,
     (m): m is StrMap<t.TypeOf<C>> => m instanceof StrMap && Object.keys(m.value).every(key => codec.is(m.value[key])),

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,20 +1,24 @@
 // Date
-export { date, DateType } from './Date/date'
-export { DateFromISOString, DateFromISOStringType } from './Date/DateFromISOString'
-export { DateFromNumber, DateFromNumberType } from './Date/DateFromNumber'
-export { DateFromUnixTime, DateFromUnixTimeType } from './Date/DateFromUnixTime'
+export { date, DateC, DateType } from './Date/date'
+export { DateFromISOString, DateFromISOStringC, DateFromISOStringType } from './Date/DateFromISOString'
+export { DateFromNumber, DateFromNumberC, DateFromNumberType } from './Date/DateFromNumber'
+export { DateFromUnixTime, DateFromUnixTimeC, DateFromUnixTimeType } from './Date/DateFromUnixTime'
 
 // fp-ts
-export { createEitherFromJSON, EitherFromJSONType } from './fp-ts/createEitherFromJSON'
-export { createNonEmptyArrayFromArray, NonEmptyArrayFromArrayType } from './fp-ts/createNonEmptyArrayFromArray'
-export { createOptionFromJSON, OptionFromJSONType } from './fp-ts/createOptionFromJSON'
-export { createOptionFromNullable, OptionFromNullableType } from './fp-ts/createOptionFromNullable'
-export { createSetFromArray, SetFromArrayType } from './fp-ts/createSetFromArray'
-export { createStrMapFromDictionary, StrMapType } from './fp-ts/createStrMapFromDictionary'
+export { createEitherFromJSON, EitherFromJSONC, EitherFromJSONType } from './fp-ts/createEitherFromJSON'
+export {
+  createNonEmptyArrayFromArray,
+  NonEmptyArrayFromArrayC,
+  NonEmptyArrayFromArrayType
+} from './fp-ts/createNonEmptyArrayFromArray'
+export { createOptionFromJSON, OptionFromJSONC, OptionFromJSONType } from './fp-ts/createOptionFromJSON'
+export { createOptionFromNullable, OptionFromNullableC, OptionFromNullableType } from './fp-ts/createOptionFromNullable'
+export { createSetFromArray, SetFromArrayC, SetFromArrayType } from './fp-ts/createSetFromArray'
+export { createStrMapFromDictionary, StrMapC, StrMapType } from './fp-ts/createStrMapFromDictionary'
 export { fromNullable } from './fromNullable'
 
 // JSON
-export { JSONFromString, JSONType, JSONFromStringType } from './JSON/JSONFromString'
+export { JSONFromString, JSONFromStringC, JSONType, JSONFromStringType } from './JSON/JSONFromString'
 export { JSONTypeRT } from './JSON/JSONTypeRT'
 
 // monocle-ts
@@ -29,17 +33,17 @@ export { fromNewtypeCurried } from './newtype-ts/fromNewtype'
 export { fromRefinement } from './newtype-ts/fromRefinement'
 
 // boolean
-export { BooleanFromString, BooleanFromStringType } from './boolean/BooleanFromString'
+export { BooleanFromString, BooleanFromStringC, BooleanFromStringType } from './boolean/BooleanFromString'
 
 // number
-export { IntegerFromString } from './number/IntegerFromString'
-export { NumberFromString, NumberFromStringType } from './number/NumberFromString'
+export { IntegerFromString, IntegerFromStringC } from './number/IntegerFromString'
+export { NumberFromString, NumberFromStringC, NumberFromStringType } from './number/NumberFromString'
 
 // top level
 export { mapOutput } from './mapOutput'
 
 // UUID
-export { uuid } from './string/uuid'
+export { uuid, uuidC } from './string/uuid'
 
 // io-ts
 export { fallback } from './fallback'


### PR DESCRIPTION
I've exported all relevant types.
Also I've changed t.dictionary in favor of t.record because I had the compiler (or linter?) complaining about `t.dictionary` deprecation.

@gcanti can we merge/release this ASAP? (I've made substantial changes to cope with all new changes and would like to deliver it soon :) )