### PR TITLE
Fix TS2440 in 0.4.x branch when using TypeScript 3.7

### DIFF
--- a/docs/modules/JSON/JSONFromString.ts.md
+++ b/docs/modules/JSON/JSONFromString.ts.md
@@ -9,9 +9,9 @@ parent: Modules
 <h2 class="text-delta">Table of contents</h2>
 
 - [JSONFromStringC (interface)](#jsonfromstringc-interface)
-- [JSONType (type alias)](#jsontype-type-alias)
 - [JSONFromStringType (class)](#jsonfromstringtype-class)
 - [JSONFromString (constant)](#jsonfromstring-constant)
+- [JSONType (export)](#jsontype-export)
 
 ---
 
@@ -21,14 +21,6 @@ parent: Modules
 
 ```ts
 export interface JSONFromStringC extends JSONFromStringType {}
-```
-
-# JSONType (type alias)
-
-**Signature**
-
-```ts
-export type JSONType = JSONType
 ```
 
 # JSONFromStringType (class)
@@ -57,4 +49,12 @@ import { JSONFromString } from 'io-ts-types/lib/JSON/JSONFromString'
 import { right } from 'fp-ts/lib/Either'
 
 assert.deepStrictEqual(JSONFromString.decode('{"name":"Giulio"}'), right({ name: 'Giulio' }))
+```
+
+# JSONType (export)
+
+**Signature**
+
+```ts
+export { JSONType } from './JSONTypeRT'
 ```

--- a/src/JSON/JSONFromString.ts
+++ b/src/JSON/JSONFromString.ts
@@ -2,7 +2,7 @@ import * as t from 'io-ts'
 import { JSONType, JSONTypeRT } from './JSONTypeRT'
 import { tryCatch } from 'fp-ts/lib/Either'
 
-export type JSONType = JSONType
+export { JSONType } from './JSONTypeRT'
 
 export class JSONFromStringType extends t.Type<JSONType> {
   readonly _tag: 'JSONFromStringType' = 'JSONFromStringType'


### PR DESCRIPTION
**Motivation:**

When compiling TS 3.7 project with `io-ts-types` of 0.4.x branch, the compiler complains about TS2440 error:

```
ERROR in [at-loader] ./node_modules/io-ts-types/lib/JSON/JSONFromString.d.ts:2:10
    TS2440: Import declaration conflicts with local declaration of 'JSONType'.
```

This fix re-exports existing `JSONType` type instead of declaring and exporting an alias.
