### PR TITLE
added alt function

### DIFF
--- a/docs/modules/BooleanFromString.ts.md
+++ b/docs/modules/BooleanFromString.ts.md
@@ -1,6 +1,6 @@
 ---
 title: BooleanFromString.ts
-nav_order: 1
+nav_order: 2
 parent: Modules
 ---
 

--- a/docs/modules/DateFromISOString.ts.md
+++ b/docs/modules/DateFromISOString.ts.md
@@ -1,6 +1,6 @@
 ---
 title: DateFromISOString.ts
-nav_order: 4
+nav_order: 5
 parent: Modules
 ---
 

--- a/docs/modules/DateFromNumber.ts.md
+++ b/docs/modules/DateFromNumber.ts.md
@@ -1,6 +1,6 @@
 ---
 title: DateFromNumber.ts
-nav_order: 5
+nav_order: 6
 parent: Modules
 ---
 

--- a/docs/modules/DateFromUnixTime.ts.md
+++ b/docs/modules/DateFromUnixTime.ts.md
@@ -1,6 +1,6 @@
 ---
 title: DateFromUnixTime.ts
-nav_order: 6
+nav_order: 7
 parent: Modules
 ---
 

--- a/docs/modules/IntFromString.ts.md
+++ b/docs/modules/IntFromString.ts.md
@@ -1,6 +1,6 @@
 ---
 title: IntFromString.ts
-nav_order: 13
+nav_order: 14
 parent: Modules
 ---
 

--- a/docs/modules/NonEmptyString.ts.md
+++ b/docs/modules/NonEmptyString.ts.md
@@ -1,6 +1,6 @@
 ---
 title: NonEmptyString.ts
-nav_order: 16
+nav_order: 17
 parent: Modules
 ---
 

--- a/docs/modules/NumberFromString.ts.md
+++ b/docs/modules/NumberFromString.ts.md
@@ -1,6 +1,6 @@
 ---
 title: NumberFromString.ts
-nav_order: 17
+nav_order: 18
 parent: Modules
 ---
 

--- a/docs/modules/UUID.ts.md
+++ b/docs/modules/UUID.ts.md
@@ -1,6 +1,6 @@
 ---
 title: UUID.ts
-nav_order: 22
+nav_order: 23
 parent: Modules
 ---
 

--- a/docs/modules/alt.ts.md
+++ b/docs/modules/alt.ts.md
@@ -1,0 +1,57 @@
+---
+title: alt.ts
+nav_order: 1
+parent: Modules
+---
+
+---
+
+<h2 class="text-delta">Table of contents</h2>
+
+- [alt (function)](#alt-function)
+
+---
+
+# alt (function)
+
+Alternative codec for the same output, the encoder will be the first parameter that provided to `alt`
+this function is good when you know that you want some type but the input can be in multiple form
+
+**Signature**
+
+```ts
+export function alt<A, IA, IB, O, OB>(
+  a: Type<A, O, IA>,
+  b: Type<A, OB, IB>,
+  name: string = `alt(${a.name}, ${b.name})`
+): Type<A, O, IA | IB> { ... }
+```
+
+**Example**
+
+```ts
+import { NumberFromString } from 'io-ts-types/lib/NumberFromString'
+import { DateFromISOString } from 'io-ts-types/lib/DateFromISOString'
+import { date } from 'io-ts-types/lib/date'
+import { right } from 'fp-ts/lib/Either'
+import { alt } from 'io-ts-types/lib/alt'
+import * as t from 'io-ts'
+import { PathReporter } from 'io-ts/lib/PathReporter'
+
+const T = alt(t.number, NumberFromString)
+
+assert.deepStrictEqual(T.decode('1'), right(1))
+assert.deepStrictEqual(T.decode(1), right(1))
+assert.deepStrictEqual(PathReporter.report(T.decode('a')), [
+  'Invalid value "a" supplied to : alt(number, NumberFromString)'
+])
+
+// encoder will always be the first one
+const D = alt(DateFromISOString, date)
+
+// type A = t.TypeOf<typeof D> // Date
+// type O = t.OutputOf<typeof D> // string
+
+const d = new Date(1988, 11, 10)
+assert.strictEqual(D.encode(d), '1988-12-09T20:30:00.000Z')
+```

--- a/docs/modules/alt.ts.md
+++ b/docs/modules/alt.ts.md
@@ -52,6 +52,6 @@ const D = alt(DateFromISOString, date)
 // type A = t.TypeOf<typeof D> // Date
 // type O = t.OutputOf<typeof D> // string
 
-const d = new Date(1988, 11, 10)
-assert.strictEqual(D.encode(d), '1988-12-09T20:30:00.000Z')
+const d = new Date(Date.UTC(1988, 10, 10, 0, 0, 0))
+assert.strictEqual(D.encode(d), '1988-11-10T00:00:00.000Z')
 ```

--- a/docs/modules/clone.ts.md
+++ b/docs/modules/clone.ts.md
@@ -1,6 +1,6 @@
 ---
 title: clone.ts
-nav_order: 2
+nav_order: 3
 parent: Modules
 ---
 

--- a/docs/modules/date.ts.md
+++ b/docs/modules/date.ts.md
@@ -1,6 +1,6 @@
 ---
 title: date.ts
-nav_order: 3
+nav_order: 4
 parent: Modules
 ---
 

--- a/docs/modules/either.ts.md
+++ b/docs/modules/either.ts.md
@@ -1,6 +1,6 @@
 ---
 title: either.ts
-nav_order: 7
+nav_order: 8
 parent: Modules
 ---
 

--- a/docs/modules/fromNewtype.ts.md
+++ b/docs/modules/fromNewtype.ts.md
@@ -1,6 +1,6 @@
 ---
 title: fromNewtype.ts
-nav_order: 8
+nav_order: 9
 parent: Modules
 ---
 

--- a/docs/modules/fromNullable.ts.md
+++ b/docs/modules/fromNullable.ts.md
@@ -1,6 +1,6 @@
 ---
 title: fromNullable.ts
-nav_order: 9
+nav_order: 10
 parent: Modules
 ---
 

--- a/docs/modules/fromRefinement.ts.md
+++ b/docs/modules/fromRefinement.ts.md
@@ -1,6 +1,6 @@
 ---
 title: fromRefinement.ts
-nav_order: 10
+nav_order: 11
 parent: Modules
 ---
 

--- a/docs/modules/getLenses.ts.md
+++ b/docs/modules/getLenses.ts.md
@@ -1,6 +1,6 @@
 ---
 title: getLenses.ts
-nav_order: 11
+nav_order: 12
 parent: Modules
 ---
 

--- a/docs/modules/index.ts.md
+++ b/docs/modules/index.ts.md
@@ -1,6 +1,6 @@
 ---
 title: index.ts
-nav_order: 12
+nav_order: 13
 parent: Modules
 ---
 

--- a/docs/modules/mapOutput.ts.md
+++ b/docs/modules/mapOutput.ts.md
@@ -1,6 +1,6 @@
 ---
 title: mapOutput.ts
-nav_order: 14
+nav_order: 15
 parent: Modules
 ---
 

--- a/docs/modules/nonEmptyArray.ts.md
+++ b/docs/modules/nonEmptyArray.ts.md
@@ -1,6 +1,6 @@
 ---
 title: nonEmptyArray.ts
-nav_order: 15
+nav_order: 16
 parent: Modules
 ---
 

--- a/docs/modules/option.ts.md
+++ b/docs/modules/option.ts.md
@@ -1,6 +1,6 @@
 ---
 title: option.ts
-nav_order: 18
+nav_order: 19
 parent: Modules
 ---
 

--- a/docs/modules/optionFromNullable.ts.md
+++ b/docs/modules/optionFromNullable.ts.md
@@ -1,6 +1,6 @@
 ---
 title: optionFromNullable.ts
-nav_order: 19
+nav_order: 20
 parent: Modules
 ---
 

--- a/docs/modules/regexp.ts.md
+++ b/docs/modules/regexp.ts.md
@@ -1,6 +1,6 @@
 ---
 title: regexp.ts
-nav_order: 20
+nav_order: 21
 parent: Modules
 ---
 

--- a/docs/modules/setFromArray.ts.md
+++ b/docs/modules/setFromArray.ts.md
@@ -1,6 +1,6 @@
 ---
 title: setFromArray.ts
-nav_order: 21
+nav_order: 22
 parent: Modules
 ---
 

--- a/docs/modules/withFallback.ts.md
+++ b/docs/modules/withFallback.ts.md
@@ -1,6 +1,6 @@
 ---
 title: withFallback.ts
-nav_order: 23
+nav_order: 24
 parent: Modules
 ---
 

--- a/docs/modules/withMessage.ts.md
+++ b/docs/modules/withMessage.ts.md
@@ -1,6 +1,6 @@
 ---
 title: withMessage.ts
-nav_order: 24
+nav_order: 25
 parent: Modules
 ---
 

--- a/docs/modules/withValidate.ts.md
+++ b/docs/modules/withValidate.ts.md
@@ -1,6 +1,6 @@
 ---
 title: withValidate.ts
-nav_order: 25
+nav_order: 26
 parent: Modules
 ---
 

--- a/src/alt.ts
+++ b/src/alt.ts
@@ -1,0 +1,40 @@
+import { Type } from 'io-ts'
+import * as E from 'fp-ts/lib/Either'
+
+/**
+ * Alternative codec for the same output, the encoder will be the first parameter that provided to `alt`
+ * this function is good when you know that you want some type but the input can be in multiple form
+ *
+ * @example
+ * import { NumberFromString } from 'io-ts-types/lib/NumberFromString'
+ * import { DateFromISOString } from 'io-ts-types/lib/DateFromISOString'
+ * import {date} from 'io-ts-types/lib/date'
+ * import { right } from 'fp-ts/lib/Either'
+ * import { alt } from 'io-ts-types/lib/alt'
+ * import * as t from 'io-ts'
+ * import { PathReporter } from 'io-ts/lib/PathReporter'
+ *
+ * const T = alt(t.number, NumberFromString)
+ *
+ * assert.deepStrictEqual(T.decode('1'), right(1))
+ * assert.deepStrictEqual(T.decode(1), right(1))
+ * assert.deepStrictEqual(PathReporter.report(T.decode('a')), ['Invalid value "a" supplied to : alt(number, NumberFromString)'])
+ *
+ * // encoder will always be the first one
+ * const D = alt(DateFromISOString, date)
+ *
+ * // type A = t.TypeOf<typeof D> // Date
+ * // type O = t.OutputOf<typeof D> // string
+ *
+ * const d = new Date(1988, 11, 10)
+ * assert.strictEqual(D.encode(d), '1988-12-09T20:30:00.000Z')
+ *
+ *
+ */
+export function alt<A, IA, IB, O, OB>(
+  a: Type<A, O, IA>,
+  b: Type<A, OB, IB>,
+  name: string = `alt(${a.name}, ${b.name})`
+): Type<A, O, IA | IB> {
+  return new Type(name, a.is, (i, c) => E.alt(() => b.validate(i as IB, c))(a.validate(i as IA, c)), a.encode)
+}

--- a/src/alt.ts
+++ b/src/alt.ts
@@ -26,8 +26,8 @@ import * as E from 'fp-ts/lib/Either'
  * // type A = t.TypeOf<typeof D> // Date
  * // type O = t.OutputOf<typeof D> // string
  *
- * const d = new Date(1988, 11, 10)
- * assert.strictEqual(D.encode(d), '1988-12-09T20:30:00.000Z')
+ * const d = new Date(Date.UTC(1988, 10, 10, 0, 0, 0))
+ * assert.strictEqual(D.encode(d), '1988-11-10T00:00:00.000Z')
  *
  *
  */

--- a/test/alt.ts
+++ b/test/alt.ts
@@ -26,7 +26,9 @@ describe('alt', () => {
 
   it('should encode with first codec provided', () => {
     const T = alt(DateFromISOString, date)
-    const d = new Date(1988, 11, 10)
-    assert.strictEqual(T.encode(d), '1988-12-09T20:30:00.000Z')
+
+    const d = new Date(Date.UTC(1988, 10, 10, 0, 0, 0))
+
+    assert.strictEqual(T.encode(d), '1988-11-10T00:00:00.000Z')
   })
 })

--- a/test/alt.ts
+++ b/test/alt.ts
@@ -1,0 +1,32 @@
+import { PathReporter } from 'io-ts/lib/PathReporter'
+import { right } from 'fp-ts/lib/Either'
+import * as assert from 'assert'
+import * as t from 'io-ts'
+import { NumberFromString } from '../src/NumberFromString'
+import { date } from '../src/date'
+import { DateFromISOString } from '../src/DateFromISOString'
+import { alt } from '../src/alt'
+
+describe('alt', () => {
+  it('name', () => {
+    const T = alt(t.number, NumberFromString, 'number')
+    assert.strictEqual(T.name, 'number')
+  })
+
+  it('should both validate check number and string to number', () => {
+    const T = alt(t.number, NumberFromString, 'number')
+    assert.deepStrictEqual(T.decode('2'), right(2))
+    assert.deepStrictEqual(T.decode(2), right(2))
+  })
+
+  it('should return a left either if runtime checks fails', () => {
+    const T = alt(t.number, NumberFromString, 'number')
+    assert.deepStrictEqual(PathReporter.report(T.decode('a')), ['Invalid value "a" supplied to : number'])
+  })
+
+  it('should encode with first codec provided', () => {
+    const T = alt(DateFromISOString, date)
+    const d = new Date(1988, 11, 10)
+    assert.strictEqual(T.encode(d), '1988-12-09T20:30:00.000Z')
+  })
+})


### PR DESCRIPTION
I wrote a function named `alt` this function will accept two codecs, both of them should have the same output type, but their input type can be different 

Alternative codec for the same output, the encoder will be the first parameter that provided to `alt` this function is good when you know that you want some type but the input can be in multiple forms

```typescript
import { NumberFromString } from 'io-ts-types/lib/NumberFromString'
import { DateFromISOString } from 'io-ts-types/lib/DateFromISOString'
import {date} from 'io-ts-types/lib/date'
import { right } from 'fp-ts/lib/Either'
import { alt } from 'io-ts-types/lib/alt'
import * as t from 'io-ts'
import { PathReporter } from 'io-ts/lib/PathReporter'
const T = alt(t.number, NumberFromString)

assert.deepStrictEqual(T.decode('1'), right(1))
assert.deepStrictEqual(T.decode(1), right(1))
assert.deepStrictEqual(PathReporter.report(T.decode('a')), ['Invalid value "a" supplied to : alt(number, NumberFromString)'])

// encoder will always be the first one
const D = alt(DateFromISOString, date)

// type A = t.TypeOf<typeof D> // Date
// type O = t.OutputOf<typeof D> // string

const d = new Date(Date.UTC(1988, 10, 10, 0, 0, 0))
assert.strictEqual(D.encode(d), '1988-11-10T00:00:00.000Z')
```