### PR TITLE
fromNewtype non primitive type support added

### DIFF
--- a/docs/modules/fromNewtype.ts.md
+++ b/docs/modules/fromNewtype.ts.md
@@ -24,7 +24,7 @@ Returns a codec from a newtype
 
 ```ts
 export function fromNewtype<N extends AnyNewtype = never>(
-  codec: t.Type<CarrierOf<N>>,
+  codec: t.Type<CarrierOf<N>, t.OutputOf<CarrierOf<N>>>,
   name = `fromNewtype(${codec.name})`
 ): t.Type<N, CarrierOf<N>, unknown> { ... }
 ```

--- a/src/fromNewtype.ts
+++ b/src/fromNewtype.ts
@@ -25,7 +25,7 @@ import { either } from 'fp-ts/lib/Either'
  * @since 0.5.2
  */
 export function fromNewtype<N extends AnyNewtype = never>(
-  codec: t.Type<CarrierOf<N>>,
+  codec: t.Type<CarrierOf<N>, t.OutputOf<CarrierOf<N>>>,
   name = `fromNewtype(${codec.name})`
 ): t.Type<N, CarrierOf<N>, unknown> {
   const i = iso<N>()

--- a/test/fromNewtype.ts
+++ b/test/fromNewtype.ts
@@ -12,6 +12,15 @@ it('fromNewtype', () => {
   assertFailure(T, 42, ['Invalid value 42 supplied to : fromNewtype(string)'])
   assert.ok(T.is('sometoken'))
   assert.deepStrictEqual(T.encode(token), 'sometoken')
+
   const T2 = fromNewtype<Token>(t.string, 'T2')
   assert.strictEqual(T2.name, 'T2')
+
+  interface Id extends Newtype<{ readonly Id: unique symbol }, t.Int> {}
+  const T3 = fromNewtype<Id>(t.Int)
+  const id = iso<Id>().wrap(123 as any)
+  assertSuccess(T3.decode(123), id)
+  assertFailure(T3, 'test', ['Invalid value "test" supplied to : fromNewtype(Int)'])
+  assert.ok(T3.is(123))
+  assert.deepStrictEqual(T3.encode(id), 123)
 })


### PR DESCRIPTION
Without this change it not possible to use any type where the `A` is unequal to the `O` of `Type<A, O>`. I had the problem when using `Int` from `io-ts` as codec.

I added a test to prevent regression.