### PR TITLE
feat: export each module's exports from the library entrypoint

### DIFF
--- a/docs/modules/index.ts.md
+++ b/docs/modules/index.ts.md
@@ -6,7 +6,7 @@ parent: Modules
 
 # index overview
 
-Added in v0.5.0
+Added in v0.5.7
 
 ---
 

--- a/dtslint/ts3.5/index.ts
+++ b/dtslint/ts3.5/index.ts
@@ -1,11 +1,6 @@
 import { ordNumber } from 'fp-ts/lib/Ord'
 import * as t from 'io-ts'
-import { either } from '../../src/either'
-import { nonEmptyArray } from '../../src/nonEmptyArray'
-import { NumberFromString } from '../../src/NumberFromString'
-import { option } from '../../src/option'
-import { optionFromNullable } from '../../src/optionFromNullable'
-import { setFromArray } from '../../src/setFromArray'
+import { either, nonEmptyArray, NumberFromString, option, optionFromNullable, setFromArray } from '../../src'
 
 //
 // either

--- a/dtslint/ts3.5/readonlyNonEmptyArray.ts
+++ b/dtslint/ts3.5/readonlyNonEmptyArray.ts
@@ -1,5 +1,5 @@
 import * as t from 'io-ts'
-import { readonlyNonEmptyArray } from '../../src/readonlyNonEmptyArray'
+import { readonlyNonEmptyArray } from '../../src'
 
 const RNAS = readonlyNonEmptyArray(t.string)
 

--- a/dtslint/ts3.5/readonlySetFromArray.ts
+++ b/dtslint/ts3.5/readonlySetFromArray.ts
@@ -1,5 +1,5 @@
 import * as t from 'io-ts'
-import { readonlySetFromArray } from '../../src/readonlySetFromArray'
+import { readonlySetFromArray } from '../../src'
 import { ordString } from 'fp-ts/lib/Ord'
 
 const RS = readonlySetFromArray(t.string, ordString)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "io-ts-types",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,129 @@
 /**
- * @since 0.5.0
+ * @since 0.5.7
  */
-export {}
+export * from './mapOutput'
+
+/**
+ * @since 0.5.7
+ */
+export * from './NonEmptyString'
+
+/**
+ * @since 0.5.7
+ */
+export * from './nonEmptyArray'
+
+/**
+ * @since 0.5.7
+ */
+export * from './readonlySetFromArray'
+
+/**
+ * @since 0.5.7
+ */
+export * from './fromRefinement'
+
+/**
+ * @since 0.5.7
+ */
+export * from './date'
+
+/**
+ * @since 0.5.7
+ */
+export * from './fromNewtype'
+
+/**
+ * @since 0.5.7
+ */
+export * from './optionFromNullable'
+
+/**
+ * @since 0.5.7
+ */
+export * from './DateFromISOString'
+
+/**
+ * @since 0.5.7
+ */
+export * from './readonlyNonEmptyArray'
+
+/**
+ * @since 0.5.7
+ */
+export * from './clone'
+
+/**
+ * @since 0.5.7
+ */
+export * from './DateFromNumber'
+
+/**
+ * @since 0.5.7
+ */
+export * from './withFallback'
+
+/**
+ * @since 0.5.7
+ */
+export * from './UUID'
+
+/**
+ * @since 0.5.7
+ */
+export * from './fromNullable'
+
+/**
+ * @since 0.5.7
+ */
+export * from './BooleanFromString'
+
+/**
+ * @since 0.5.7
+ */
+export * from './withMessage'
+
+/**
+ * @since 0.5.7
+ */
+export * from './withValidate'
+
+/**
+ * @since 0.5.7
+ */
+export * from './getLenses'
+
+/**
+ * @since 0.5.7
+ */
+export * from './regexp'
+
+/**
+ * @since 0.5.7
+ */
+export * from './option'
+
+/**
+ * @since 0.5.7
+ */
+export * from './DateFromUnixTime'
+
+/**
+ * @since 0.5.7
+ */
+export * from './NumberFromString'
+
+/**
+ * @since 0.5.7
+ */
+export * from './setFromArray'
+
+/**
+ * @since 0.5.7
+ */
+export * from './IntFromString'
+
+/**
+ * @since 0.5.7
+ */
+export * from './either'

--- a/test/BooleanFromString.ts
+++ b/test/BooleanFromString.ts
@@ -1,4 +1,4 @@
-import { BooleanFromString } from '../src/BooleanFromString'
+import { BooleanFromString } from '../src'
 import { assertSuccess, assertFailure } from './helpers'
 
 describe('BooleanFromString', () => {

--- a/test/DateFromISOString.ts
+++ b/test/DateFromISOString.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert'
-import { DateFromISOString } from '../src/DateFromISOString'
+import { DateFromISOString } from '../src'
 import { assertSuccess, assertFailure } from './helpers'
 
 const d = new Date(1973, 10, 30)

--- a/test/DateFromNumber.ts
+++ b/test/DateFromNumber.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert'
-import { DateFromNumber } from '../src/DateFromNumber'
+import { DateFromNumber } from '../src'
 import { assertSuccess, assertFailure } from './helpers'
 import { either } from 'fp-ts/lib/Either'
 

--- a/test/DateFromUnixTime.ts
+++ b/test/DateFromUnixTime.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert'
-import { DateFromUnixTime } from '../src/DateFromUnixTime'
+import { DateFromUnixTime } from '../src'
 import { assertSuccess, assertFailure } from './helpers'
 import { either } from 'fp-ts/lib/Either'
 

--- a/test/IntFromString.ts
+++ b/test/IntFromString.ts
@@ -1,4 +1,4 @@
-import { IntFromString } from '../src/IntFromString'
+import { IntFromString } from '../src'
 import { assertSuccess, assertFailure } from './helpers'
 import * as t from 'io-ts'
 

--- a/test/NonEmptyString.ts
+++ b/test/NonEmptyString.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert'
-import { NonEmptyString } from '../src/NonEmptyString'
+import { NonEmptyString } from '../src'
 import { assertSuccess, assertFailure } from './helpers'
 
 describe('NonEmptyString', () => {

--- a/test/NumberFromString.ts
+++ b/test/NumberFromString.ts
@@ -1,5 +1,5 @@
 import { assertSuccess, assertFailure } from './helpers'
-import { NumberFromString } from '../src/NumberFromString'
+import { NumberFromString } from '../src'
 
 describe('NumberFromString', () => {
   it('decode', () => {

--- a/test/UUID.ts
+++ b/test/UUID.ts
@@ -1,4 +1,4 @@
-import { UUID } from '../src/UUID'
+import { UUID } from '../src'
 import { assertFailure, assertSuccess } from './helpers'
 
 describe('UUID', () => {

--- a/test/date.ts
+++ b/test/date.ts
@@ -1,4 +1,4 @@
-import { date } from '../src/date'
+import { date } from '../src'
 import { assertFailure, assertSuccess } from './helpers'
 
 describe('Date', () => {

--- a/test/either.ts
+++ b/test/either.ts
@@ -1,7 +1,7 @@
 import * as assert from 'assert'
 import { left, right } from 'fp-ts/lib/Either'
 import * as t from 'io-ts'
-import { either } from '../src/either'
+import { either } from '../src'
 import { assertFailure, assertSuccess } from './helpers'
 
 describe('either', () => {

--- a/test/fromNewtype.ts
+++ b/test/fromNewtype.ts
@@ -1,6 +1,6 @@
 import * as assert from 'assert'
 import * as t from 'io-ts'
-import { fromNewtype } from '../src/fromNewtype'
+import { fromNewtype } from '../src'
 import { assertFailure, assertSuccess } from './helpers'
 import { Newtype, iso } from 'newtype-ts'
 

--- a/test/fromNullable.ts
+++ b/test/fromNullable.ts
@@ -1,6 +1,6 @@
 import * as assert from 'assert'
 import * as t from 'io-ts'
-import { fromNullable } from '../src/fromNullable'
+import { fromNullable } from '../src'
 import { assertFailure, assertSuccess } from './helpers'
 
 it('fromNullable', () => {

--- a/test/getLenses.ts
+++ b/test/getLenses.ts
@@ -1,6 +1,6 @@
 import * as assert from 'assert'
 import * as t from 'io-ts'
-import { getLenses } from '../src/getLenses'
+import { getLenses } from '../src'
 import { Lens } from 'monocle-ts'
 
 describe('getLenses', () => {

--- a/test/mapOutput.ts
+++ b/test/mapOutput.ts
@@ -1,6 +1,6 @@
 import * as assert from 'assert'
 import * as t from 'io-ts'
-import { mapOutput } from '../src/mapOutput'
+import { mapOutput } from '../src'
 
 describe('mapOutput', () => {
   it('name', () => {

--- a/test/nonEmptyArray.ts
+++ b/test/nonEmptyArray.ts
@@ -1,4 +1,4 @@
-import { nonEmptyArray } from '../src/nonEmptyArray'
+import { nonEmptyArray } from '../src'
 import * as t from 'io-ts'
 import { cons } from 'fp-ts/lib/NonEmptyArray'
 import * as assert from 'assert'

--- a/test/option.ts
+++ b/test/option.ts
@@ -1,8 +1,8 @@
 import * as assert from 'assert'
 import { none, some } from 'fp-ts/lib/Option'
 import * as t from 'io-ts'
-import { NumberFromString } from '../src/NumberFromString'
-import { option } from '../src/option'
+import { NumberFromString } from '../src'
+import { option } from '../src'
 import { assertFailure, assertSuccess } from './helpers'
 
 describe('option', () => {

--- a/test/optionFromNullable.ts
+++ b/test/optionFromNullable.ts
@@ -1,8 +1,8 @@
 import { assertSuccess, assertFailure } from './helpers'
-import { optionFromNullable } from '../src/optionFromNullable'
+import { optionFromNullable } from '../src'
 import * as t from 'io-ts'
 import * as assert from 'assert'
-import { NumberFromString } from '../src/NumberFromString'
+import { NumberFromString } from '../src'
 import { none, some } from 'fp-ts/lib/Option'
 
 describe('optionFromNullable', () => {

--- a/test/readonlyNonEmptyArray.ts
+++ b/test/readonlyNonEmptyArray.ts
@@ -1,7 +1,7 @@
 import * as assert from 'assert'
 import { cons } from 'fp-ts/lib/NonEmptyArray'
 import * as t from 'io-ts'
-import { readonlyNonEmptyArray } from '../src/readonlyNonEmptyArray'
+import { readonlyNonEmptyArray } from '../src'
 import { assertFailure, assertSuccess } from './helpers'
 
 describe('readonlyNonEmptyArray', () => {

--- a/test/readonlySetFromArray.ts
+++ b/test/readonlySetFromArray.ts
@@ -1,4 +1,4 @@
-import { readonlySetFromArray } from '../src/readonlySetFromArray'
+import { readonlySetFromArray } from '../src'
 import * as t from 'io-ts'
 import * as assert from 'assert'
 import { assertFailure, assertSuccess } from './helpers'

--- a/test/regexp.ts
+++ b/test/regexp.ts
@@ -1,4 +1,4 @@
-import { regexp } from '../src/regexp'
+import { regexp } from '../src'
 import { assertSuccess, assertFailure } from './helpers'
 
 describe('RegExp', () => {

--- a/test/setFromArray.ts
+++ b/test/setFromArray.ts
@@ -1,4 +1,4 @@
-import { setFromArray } from '../src/setFromArray'
+import { setFromArray } from '../src'
 import * as t from 'io-ts'
 import * as assert from 'assert'
 import { assertFailure, assertSuccess } from './helpers'

--- a/test/withFallback.ts
+++ b/test/withFallback.ts
@@ -1,6 +1,6 @@
 import * as assert from 'assert'
 import * as t from 'io-ts'
-import { withFallback } from '../src/withFallback'
+import { withFallback } from '../src'
 import { assertSuccess } from './helpers'
 
 describe('withFallback', () => {

--- a/test/withMessage.ts
+++ b/test/withMessage.ts
@@ -1,6 +1,6 @@
 import * as t from 'io-ts'
 import { assertFailure } from './helpers'
-import { withMessage } from '../src/withMessage'
+import { withMessage } from '../src'
 
 describe('withMessage', () => {
   it('should set the error message', () => {


### PR DESCRIPTION
I noticed that `package.json` updated automatically.
Would you like to keep this change or have it reversed?

Do we need tests to check that `index.ts` is exporting the correct modules?
If so, I'd recommend that the tests import their from `index.ts` rather than from the source.

closes #129 
