### PR TITLE
feat: pass context to withMessage callback

### DIFF
--- a/docs/modules/withMessage.ts.md
+++ b/docs/modules/withMessage.ts.md
@@ -23,7 +23,7 @@ Returns a clone of the given codec that sets the given string as error messsage
 **Signature**
 
 ```ts
-export function withMessage<C extends t.Any>(codec: C, message: (i: t.InputOf<C>) => string): C { ... }
+export function withMessage<C extends t.Any>(codec: C, message: (i: t.InputOf<C>, c: t.Context) => string): C { ... }
 ```
 
 **Example**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "io-ts-types",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/withMessage.ts
+++ b/src/withMessage.ts
@@ -21,13 +21,13 @@ import { mapLeft } from 'fp-ts/lib/Either'
  *
  * @since 0.4.3
  */
-export function withMessage<C extends t.Any>(codec: C, message: (i: t.InputOf<C>) => string): C {
+export function withMessage<C extends t.Any>(codec: C, message: (i: t.InputOf<C>, c: t.Context) => string): C {
   return withValidate(codec, (i, c) =>
     mapLeft(() => [
       {
         value: i,
         context: c,
-        message: message(i),
+        message: message(i, c),
         actual: i
       }
     ])(codec.validate(i, c))


### PR DESCRIPTION
In order to create more meaningful error messages, one may need to access the context.
