### PR TITLE
feat: add BigIntFromString codec

### DIFF
--- a/docs/modules/BigIntFromString.ts.md
+++ b/docs/modules/BigIntFromString.ts.md
@@ -1,0 +1,57 @@
+---
+title: BigIntFromString.ts
+nav_order: 1
+parent: Modules
+---
+
+# BigIntFromString overview
+
+Added in v0.5.11
+
+---
+
+<h2 class="text-delta">Table of contents</h2>
+
+- [BigIntFromStringC (interface)](#bigintfromstringc-interface)
+- [BigIntFromString](#bigintfromstring)
+
+---
+
+# BigIntFromStringC (interface)
+
+**Signature**
+
+```ts
+export interface BigIntFromStringC extends t.Type<bigint, string, unknown> {}
+```
+
+Added in v0.5.11
+
+# BigIntFromString
+
+**Signature**
+
+```ts
+export const BigIntFromString: BigIntFromStringC = ...
+```
+
+**Example**
+
+```ts
+import { BigIntFromString } from 'io-ts-types/lib/BigIntFromString'
+import { right } from 'fp-ts/lib/Either'
+import { PathReporter } from 'io-ts/lib/PathReporter'
+
+assert.deepStrictEqual(BigIntFromString.decode('1'), right(BigInt(1)))
+assert.deepStrictEqual(PathReporter.report(BigIntFromString.decode('1.1')), [
+  'Invalid value "1.1" supplied to : BigIntFromString'
+])
+assert.deepStrictEqual(PathReporter.report(BigIntFromString.decode('')), [
+  'Invalid value "" supplied to : BigIntFromString'
+])
+assert.deepStrictEqual(PathReporter.report(BigIntFromString.decode(' ')), [
+  'Invalid value " " supplied to : BigIntFromString'
+])
+```
+
+Added in v0.5.11

--- a/docs/modules/BooleanFromString.ts.md
+++ b/docs/modules/BooleanFromString.ts.md
@@ -1,6 +1,6 @@
 ---
 title: BooleanFromString.ts
-nav_order: 1
+nav_order: 2
 parent: Modules
 ---
 

--- a/docs/modules/DateFromISOString.ts.md
+++ b/docs/modules/DateFromISOString.ts.md
@@ -1,6 +1,6 @@
 ---
 title: DateFromISOString.ts
-nav_order: 4
+nav_order: 5
 parent: Modules
 ---
 

--- a/docs/modules/DateFromNumber.ts.md
+++ b/docs/modules/DateFromNumber.ts.md
@@ -1,6 +1,6 @@
 ---
 title: DateFromNumber.ts
-nav_order: 5
+nav_order: 6
 parent: Modules
 ---
 

--- a/docs/modules/DateFromUnixTime.ts.md
+++ b/docs/modules/DateFromUnixTime.ts.md
@@ -1,6 +1,6 @@
 ---
 title: DateFromUnixTime.ts
-nav_order: 6
+nav_order: 7
 parent: Modules
 ---
 

--- a/docs/modules/IntFromString.ts.md
+++ b/docs/modules/IntFromString.ts.md
@@ -1,6 +1,6 @@
 ---
 title: IntFromString.ts
-nav_order: 13
+nav_order: 14
 parent: Modules
 ---
 

--- a/docs/modules/NonEmptyString.ts.md
+++ b/docs/modules/NonEmptyString.ts.md
@@ -1,6 +1,6 @@
 ---
 title: NonEmptyString.ts
-nav_order: 16
+nav_order: 17
 parent: Modules
 ---
 

--- a/docs/modules/NumberFromString.ts.md
+++ b/docs/modules/NumberFromString.ts.md
@@ -1,6 +1,6 @@
 ---
 title: NumberFromString.ts
-nav_order: 17
+nav_order: 18
 parent: Modules
 ---
 

--- a/docs/modules/UUID.ts.md
+++ b/docs/modules/UUID.ts.md
@@ -1,6 +1,6 @@
 ---
 title: UUID.ts
-nav_order: 24
+nav_order: 25
 parent: Modules
 ---
 

--- a/docs/modules/clone.ts.md
+++ b/docs/modules/clone.ts.md
@@ -1,6 +1,6 @@
 ---
 title: clone.ts
-nav_order: 2
+nav_order: 3
 parent: Modules
 ---
 

--- a/docs/modules/date.ts.md
+++ b/docs/modules/date.ts.md
@@ -1,6 +1,6 @@
 ---
 title: date.ts
-nav_order: 3
+nav_order: 4
 parent: Modules
 ---
 

--- a/docs/modules/either.ts.md
+++ b/docs/modules/either.ts.md
@@ -1,6 +1,6 @@
 ---
 title: either.ts
-nav_order: 7
+nav_order: 8
 parent: Modules
 ---
 

--- a/docs/modules/fromNewtype.ts.md
+++ b/docs/modules/fromNewtype.ts.md
@@ -1,6 +1,6 @@
 ---
 title: fromNewtype.ts
-nav_order: 8
+nav_order: 9
 parent: Modules
 ---
 

--- a/docs/modules/fromNullable.ts.md
+++ b/docs/modules/fromNullable.ts.md
@@ -1,6 +1,6 @@
 ---
 title: fromNullable.ts
-nav_order: 9
+nav_order: 10
 parent: Modules
 ---
 

--- a/docs/modules/fromRefinement.ts.md
+++ b/docs/modules/fromRefinement.ts.md
@@ -1,6 +1,6 @@
 ---
 title: fromRefinement.ts
-nav_order: 10
+nav_order: 11
 parent: Modules
 ---
 

--- a/docs/modules/getLenses.ts.md
+++ b/docs/modules/getLenses.ts.md
@@ -1,6 +1,6 @@
 ---
 title: getLenses.ts
-nav_order: 11
+nav_order: 12
 parent: Modules
 ---
 

--- a/docs/modules/index.ts.md
+++ b/docs/modules/index.ts.md
@@ -1,6 +1,6 @@
 ---
 title: index.ts
-nav_order: 12
+nav_order: 13
 parent: Modules
 ---
 

--- a/docs/modules/mapOutput.ts.md
+++ b/docs/modules/mapOutput.ts.md
@@ -1,6 +1,6 @@
 ---
 title: mapOutput.ts
-nav_order: 14
+nav_order: 15
 parent: Modules
 ---
 

--- a/docs/modules/nonEmptyArray.ts.md
+++ b/docs/modules/nonEmptyArray.ts.md
@@ -1,6 +1,6 @@
 ---
 title: nonEmptyArray.ts
-nav_order: 15
+nav_order: 16
 parent: Modules
 ---
 

--- a/docs/modules/option.ts.md
+++ b/docs/modules/option.ts.md
@@ -1,6 +1,6 @@
 ---
 title: option.ts
-nav_order: 18
+nav_order: 19
 parent: Modules
 ---
 

--- a/docs/modules/optionFromNullable.ts.md
+++ b/docs/modules/optionFromNullable.ts.md
@@ -1,6 +1,6 @@
 ---
 title: optionFromNullable.ts
-nav_order: 19
+nav_order: 20
 parent: Modules
 ---
 

--- a/docs/modules/readonlyNonEmptyArray.ts.md
+++ b/docs/modules/readonlyNonEmptyArray.ts.md
@@ -1,6 +1,6 @@
 ---
 title: readonlyNonEmptyArray.ts
-nav_order: 20
+nav_order: 21
 parent: Modules
 ---
 

--- a/docs/modules/readonlySetFromArray.ts.md
+++ b/docs/modules/readonlySetFromArray.ts.md
@@ -1,6 +1,6 @@
 ---
 title: readonlySetFromArray.ts
-nav_order: 21
+nav_order: 22
 parent: Modules
 ---
 

--- a/docs/modules/regexp.ts.md
+++ b/docs/modules/regexp.ts.md
@@ -1,6 +1,6 @@
 ---
 title: regexp.ts
-nav_order: 22
+nav_order: 23
 parent: Modules
 ---
 

--- a/docs/modules/setFromArray.ts.md
+++ b/docs/modules/setFromArray.ts.md
@@ -1,6 +1,6 @@
 ---
 title: setFromArray.ts
-nav_order: 23
+nav_order: 24
 parent: Modules
 ---
 

--- a/docs/modules/withFallback.ts.md
+++ b/docs/modules/withFallback.ts.md
@@ -1,6 +1,6 @@
 ---
 title: withFallback.ts
-nav_order: 25
+nav_order: 26
 parent: Modules
 ---
 

--- a/docs/modules/withMessage.ts.md
+++ b/docs/modules/withMessage.ts.md
@@ -1,6 +1,6 @@
 ---
 title: withMessage.ts
-nav_order: 26
+nav_order: 27
 parent: Modules
 ---
 

--- a/docs/modules/withValidate.ts.md
+++ b/docs/modules/withValidate.ts.md
@@ -1,6 +1,6 @@
 ---
 title: withValidate.ts
-nav_order: 27
+nav_order: 28
 parent: Modules
 ---
 

--- a/src/BigIntFromString.ts
+++ b/src/BigIntFromString.ts
@@ -1,0 +1,42 @@
+/**
+ * @since 0.5.11
+ */
+import * as t from 'io-ts'
+import { either } from 'fp-ts/lib/Either'
+import { NonEmptyString } from './NonEmptyString'
+
+/**
+ * @since 0.5.11
+ */
+export interface BigIntFromStringC extends t.Type<bigint, string, unknown> {}
+
+/**
+ * @example
+ * import { BigIntFromString } from 'io-ts-types/lib/BigIntFromString'
+ * import { right } from 'fp-ts/lib/Either'
+ * import { PathReporter } from 'io-ts/lib/PathReporter'
+ *
+ * assert.deepStrictEqual(BigIntFromString.decode('1'), right(BigInt(1)))
+ * assert.deepStrictEqual(PathReporter.report(BigIntFromString.decode('1.1')), ['Invalid value "1.1" supplied to : BigIntFromString'])
+ * assert.deepStrictEqual(PathReporter.report(BigIntFromString.decode('')), ['Invalid value "" supplied to : BigIntFromString'])
+ * assert.deepStrictEqual(PathReporter.report(BigIntFromString.decode(' ')), ['Invalid value " " supplied to : BigIntFromString'])
+ *
+ * @since 0.5.11
+ */
+export const BigIntFromString: BigIntFromStringC = new t.Type<bigint, string, unknown>(
+  'BigIntFromString',
+  // tslint:disable-next-line
+  (u): u is bigint => typeof u === 'bigint',
+  (u, c) =>
+    either.chain(t.string.validate(u, c), s => {
+      if (!NonEmptyString.is(s.trim())) {
+        return t.failure(u, c)
+      }
+      try {
+        return t.success(BigInt(s))
+      } catch (error) {
+        return t.failure(u, c)
+      }
+    }),
+  String
+)

--- a/src/index.ts
+++ b/src/index.ts
@@ -127,3 +127,8 @@ export * from './IntFromString'
  * @since 0.5.8
  */
 export * from './either'
+
+/**
+ * @since 0.5.11
+ */
+export * from './BigIntFromString'

--- a/test/BigIntFromString.ts
+++ b/test/BigIntFromString.ts
@@ -1,0 +1,28 @@
+import * as assert from 'assert'
+import { BigIntFromString } from '../src'
+import { assertSuccess, assertFailure } from './helpers'
+
+describe('BigIntFromString', () => {
+  it('is', () => {
+    const T = BigIntFromString
+    assert.strictEqual(T.is(BigInt(5)), true)
+    assert.strictEqual(T.is(null), false)
+  })
+  it('decode', () => {
+    const T = BigIntFromString
+    assertSuccess(T.decode('0'), BigInt(0))
+    assertSuccess(T.decode('10'), BigInt(10))
+    assertSuccess(T.decode('-1'), BigInt(-1))
+    assertSuccess(T.decode('11'), BigInt(11))
+    assertFailure(T, '5.5', ['Invalid value "5.5" supplied to : BigIntFromString'])
+    assertFailure(T, '-5.5', ['Invalid value "-5.5" supplied to : BigIntFromString'])
+    assertFailure(T, '', ['Invalid value "" supplied to : BigIntFromString'])
+    assertFailure(T, ' ', ['Invalid value " " supplied to : BigIntFromString'])
+    assertFailure(T, 'a', ['Invalid value "a" supplied to : BigIntFromString'])
+    assertFailure(T, 'a5', ['Invalid value "a5" supplied to : BigIntFromString'])
+  })
+  it('encode', () => {
+    const T = BigIntFromString
+    assert.strictEqual(T.encode(BigInt(5)), '5')
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,7 @@
     "target": "es5",
     "moduleResolution": "node",
     "forceConsistentCasingInFileNames": true,
-    "lib": ["es6", "dom"]
+    "lib": ["es6", "dom", "ESNext.BigInt"]
   },
   "include": ["./src/**/*"]
 }


### PR DESCRIPTION
Note:
- empty strings decode into a `left`
- whitespace-only strings decode into a `left`

This mirrors the behavior in the NumberFromString codec.

I reference version 0.5.11 in the docstring but haven't bumped to this version yet.