### PR TITLE
BufferFromBase64String

### DIFF
--- a/docs/modules/BufferFromBase64String.ts.md
+++ b/docs/modules/BufferFromBase64String.ts.md
@@ -1,0 +1,55 @@
+---
+title: BufferFromBase64String.ts
+nav_order: 3
+parent: Modules
+---
+
+# BufferFromBase64String overview
+
+Added in v0.5.12
+
+---
+
+<h2 class="text-delta">Table of contents</h2>
+
+- [BufferFromBase64StringC (interface)](#bufferfrombase64stringc-interface)
+- [BufferFromBase64String](#bufferfrombase64string)
+
+---
+
+# BufferFromBase64StringC (interface)
+
+**Signature**
+
+```ts
+export interface BufferFromBase64StringC extends t.Type<Buffer, string, unknown> {}
+```
+
+Added in v0.5.12
+
+# BufferFromBase64String
+
+**Signature**
+
+```ts
+export const BufferFromBase64String: BufferFromBase64StringC = ...
+```
+
+**Example**
+
+```ts
+import { BufferFromBase64String } from 'io-ts-types/lib/BufferFromBase64String'
+import { right } from 'fp-ts/lib/Either'
+import { PathReporter } from 'io-ts/lib/PathReporter'
+
+assert.deepStrictEqual(BufferFromBase64String.decode(''), right(Buffer.alloc(0)))
+assert.deepStrictEqual(BufferFromBase64String.decode('aGVsbG8='), right(Buffer.from('aGVsbG8=', 'base64')))
+assert.deepStrictEqual(PathReporter.report(BufferFromBase64String.decode('aGV     sbG8=')), [
+  'Invalid value "aGV     sbG8=" supplied to : BufferFromBase64String'
+])
+assert.deepStrictEqual(PathReporter.report(BufferFromBase64String.decode('!@#$%^')), [
+  'Invalid value "!@#$%^" supplied to : BufferFromBase64String'
+])
+```
+
+Added in v0.5.12

--- a/docs/modules/DateFromISOString.ts.md
+++ b/docs/modules/DateFromISOString.ts.md
@@ -1,6 +1,6 @@
 ---
 title: DateFromISOString.ts
-nav_order: 5
+nav_order: 6
 parent: Modules
 ---
 

--- a/docs/modules/DateFromNumber.ts.md
+++ b/docs/modules/DateFromNumber.ts.md
@@ -1,6 +1,6 @@
 ---
 title: DateFromNumber.ts
-nav_order: 6
+nav_order: 7
 parent: Modules
 ---
 

--- a/docs/modules/DateFromUnixTime.ts.md
+++ b/docs/modules/DateFromUnixTime.ts.md
@@ -1,6 +1,6 @@
 ---
 title: DateFromUnixTime.ts
-nav_order: 7
+nav_order: 8
 parent: Modules
 ---
 

--- a/docs/modules/IntFromString.ts.md
+++ b/docs/modules/IntFromString.ts.md
@@ -1,6 +1,6 @@
 ---
 title: IntFromString.ts
-nav_order: 14
+nav_order: 15
 parent: Modules
 ---
 

--- a/docs/modules/NonEmptyString.ts.md
+++ b/docs/modules/NonEmptyString.ts.md
@@ -1,6 +1,6 @@
 ---
 title: NonEmptyString.ts
-nav_order: 17
+nav_order: 18
 parent: Modules
 ---
 

--- a/docs/modules/NumberFromString.ts.md
+++ b/docs/modules/NumberFromString.ts.md
@@ -1,6 +1,6 @@
 ---
 title: NumberFromString.ts
-nav_order: 18
+nav_order: 19
 parent: Modules
 ---
 

--- a/docs/modules/UUID.ts.md
+++ b/docs/modules/UUID.ts.md
@@ -1,6 +1,6 @@
 ---
 title: UUID.ts
-nav_order: 25
+nav_order: 26
 parent: Modules
 ---
 

--- a/docs/modules/clone.ts.md
+++ b/docs/modules/clone.ts.md
@@ -1,6 +1,6 @@
 ---
 title: clone.ts
-nav_order: 3
+nav_order: 4
 parent: Modules
 ---
 

--- a/docs/modules/date.ts.md
+++ b/docs/modules/date.ts.md
@@ -1,6 +1,6 @@
 ---
 title: date.ts
-nav_order: 4
+nav_order: 5
 parent: Modules
 ---
 

--- a/docs/modules/either.ts.md
+++ b/docs/modules/either.ts.md
@@ -1,6 +1,6 @@
 ---
 title: either.ts
-nav_order: 8
+nav_order: 9
 parent: Modules
 ---
 

--- a/docs/modules/fromNewtype.ts.md
+++ b/docs/modules/fromNewtype.ts.md
@@ -1,6 +1,6 @@
 ---
 title: fromNewtype.ts
-nav_order: 9
+nav_order: 10
 parent: Modules
 ---
 

--- a/docs/modules/fromNullable.ts.md
+++ b/docs/modules/fromNullable.ts.md
@@ -1,6 +1,6 @@
 ---
 title: fromNullable.ts
-nav_order: 10
+nav_order: 11
 parent: Modules
 ---
 

--- a/docs/modules/fromRefinement.ts.md
+++ b/docs/modules/fromRefinement.ts.md
@@ -1,6 +1,6 @@
 ---
 title: fromRefinement.ts
-nav_order: 11
+nav_order: 12
 parent: Modules
 ---
 

--- a/docs/modules/getLenses.ts.md
+++ b/docs/modules/getLenses.ts.md
@@ -1,6 +1,6 @@
 ---
 title: getLenses.ts
-nav_order: 12
+nav_order: 13
 parent: Modules
 ---
 

--- a/docs/modules/index.ts.md
+++ b/docs/modules/index.ts.md
@@ -1,6 +1,6 @@
 ---
 title: index.ts
-nav_order: 13
+nav_order: 14
 parent: Modules
 ---
 

--- a/docs/modules/mapOutput.ts.md
+++ b/docs/modules/mapOutput.ts.md
@@ -1,6 +1,6 @@
 ---
 title: mapOutput.ts
-nav_order: 15
+nav_order: 16
 parent: Modules
 ---
 

--- a/docs/modules/nonEmptyArray.ts.md
+++ b/docs/modules/nonEmptyArray.ts.md
@@ -1,6 +1,6 @@
 ---
 title: nonEmptyArray.ts
-nav_order: 16
+nav_order: 17
 parent: Modules
 ---
 

--- a/docs/modules/option.ts.md
+++ b/docs/modules/option.ts.md
@@ -1,6 +1,6 @@
 ---
 title: option.ts
-nav_order: 19
+nav_order: 20
 parent: Modules
 ---
 

--- a/docs/modules/optionFromNullable.ts.md
+++ b/docs/modules/optionFromNullable.ts.md
@@ -1,6 +1,6 @@
 ---
 title: optionFromNullable.ts
-nav_order: 20
+nav_order: 21
 parent: Modules
 ---
 

--- a/docs/modules/readonlyNonEmptyArray.ts.md
+++ b/docs/modules/readonlyNonEmptyArray.ts.md
@@ -1,6 +1,6 @@
 ---
 title: readonlyNonEmptyArray.ts
-nav_order: 21
+nav_order: 22
 parent: Modules
 ---
 

--- a/docs/modules/readonlySetFromArray.ts.md
+++ b/docs/modules/readonlySetFromArray.ts.md
@@ -1,6 +1,6 @@
 ---
 title: readonlySetFromArray.ts
-nav_order: 22
+nav_order: 23
 parent: Modules
 ---
 

--- a/docs/modules/regexp.ts.md
+++ b/docs/modules/regexp.ts.md
@@ -1,6 +1,6 @@
 ---
 title: regexp.ts
-nav_order: 23
+nav_order: 24
 parent: Modules
 ---
 

--- a/docs/modules/setFromArray.ts.md
+++ b/docs/modules/setFromArray.ts.md
@@ -1,6 +1,6 @@
 ---
 title: setFromArray.ts
-nav_order: 24
+nav_order: 25
 parent: Modules
 ---
 

--- a/docs/modules/withEncode.ts.md
+++ b/docs/modules/withEncode.ts.md
@@ -1,6 +1,6 @@
 ---
 title: withEncode.ts
-nav_order: 26
+nav_order: 27
 parent: Modules
 ---
 

--- a/docs/modules/withFallback.ts.md
+++ b/docs/modules/withFallback.ts.md
@@ -1,6 +1,6 @@
 ---
 title: withFallback.ts
-nav_order: 26
+nav_order: 27
 parent: Modules
 ---
 

--- a/docs/modules/withFallback.ts.md
+++ b/docs/modules/withFallback.ts.md
@@ -1,6 +1,6 @@
 ---
 title: withFallback.ts
-nav_order: 27
+nav_order: 28
 parent: Modules
 ---
 

--- a/docs/modules/withMessage.ts.md
+++ b/docs/modules/withMessage.ts.md
@@ -1,6 +1,6 @@
 ---
 title: withMessage.ts
-nav_order: 27
+nav_order: 28
 parent: Modules
 ---
 

--- a/docs/modules/withMessage.ts.md
+++ b/docs/modules/withMessage.ts.md
@@ -1,6 +1,6 @@
 ---
 title: withMessage.ts
-nav_order: 28
+nav_order: 29
 parent: Modules
 ---
 

--- a/docs/modules/withValidate.ts.md
+++ b/docs/modules/withValidate.ts.md
@@ -1,6 +1,6 @@
 ---
 title: withValidate.ts
-nav_order: 28
+nav_order: 29
 parent: Modules
 ---
 

--- a/docs/modules/withValidate.ts.md
+++ b/docs/modules/withValidate.ts.md
@@ -1,6 +1,6 @@
 ---
 title: withValidate.ts
-nav_order: 29
+nav_order: 30
 parent: Modules
 ---
 

--- a/src/BufferFromBase64String.ts
+++ b/src/BufferFromBase64String.ts
@@ -13,7 +13,7 @@ export interface BufferFromBase64StringC extends t.Type<Buffer, string, unknown>
 
 /**
  * @example
- * import { BufferFromBase64String } from 'io-ts-types/lib/BigIntFromString'
+ * import { BufferFromBase64String } from 'io-ts-types/lib/BufferFromBase64String'
  * import { right } from 'fp-ts/lib/Either'
  * import { PathReporter } from 'io-ts/lib/PathReporter'
  *

--- a/src/BufferFromBase64String.ts
+++ b/src/BufferFromBase64String.ts
@@ -1,0 +1,37 @@
+/**
+ * @since 0.5.12
+ */
+import * as t from 'io-ts'
+import { either } from 'fp-ts/lib/Either'
+
+const base64regex = /^(?:[A-Za-z0-9+\\/]{4})*(?:[A-Za-z0-9+\\/]{2}==|[A-Za-z0-9+/]{3}=)?$/
+
+/**
+ * @since 0.5.12
+ */
+export interface BufferFromBase64StringC extends t.Type<Buffer, string, unknown> {}
+
+/**
+ * @example
+ * import { BufferFromBase64String } from 'io-ts-types/lib/BigIntFromString'
+ * import { right } from 'fp-ts/lib/Either'
+ * import { PathReporter } from 'io-ts/lib/PathReporter'
+ *
+ * assert.deepStrictEqual(BufferFromBase64String.decode(''), right(Buffer.alloc(0)))
+ * assert.deepStrictEqual(BufferFromBase64String.decode('aGVsbG8='), right(Buffer.from('aGVsbG8=', 'base64')))
+ * assert.deepStrictEqual(PathReporter.report(BufferFromBase64String.decode('aGV     sbG8=')), ['Invalid value "aGV     sbG8=" supplied to : BufferFromBase64String'])
+ * assert.deepStrictEqual(PathReporter.report(BufferFromBase64String.decode( '!@#$%^')), ['Invalid value "!@#$%^" supplied to : BufferFromBase64String'])
+ * @since 0.5.12
+ */
+export const BufferFromBase64String: BufferFromBase64StringC = new t.Type<Buffer, string, unknown>(
+  'BufferFromBase64String',
+  (u): u is Buffer => u instanceof Buffer,
+  (u, c) =>
+    either.chain(t.string.validate(u, c), s => {
+      if (!base64regex.test(s)) {
+        return t.failure(u, c)
+      }
+      return t.success(Buffer.from(s, 'base64'))
+    }),
+  a => a.toString('base64')
+)

--- a/src/index.ts
+++ b/src/index.ts
@@ -132,3 +132,8 @@ export * from './either'
  * @since 0.5.11
  */
 export * from './BigIntFromString'
+
+/**
+ * @since 0.5.12
+ */
+export * from './BufferFromBase64String'

--- a/test/BufferFromBase64String.ts
+++ b/test/BufferFromBase64String.ts
@@ -1,0 +1,21 @@
+import * as assert from 'assert'
+import { BufferFromBase64String } from '../src'
+import { assertFailure, assertSuccess } from './helpers'
+
+describe('BufferFromBase64String', () => {
+  const T = BufferFromBase64String
+  it('is', () => {
+    assert.strictEqual(T.is(Buffer.alloc(1)), true)
+    assert.strictEqual(T.is(null), false)
+  })
+  it('decode', () => {
+    assertSuccess(T.decode(''), Buffer.alloc(0))
+    assertSuccess(T.decode('aGVsbG8='), Buffer.from('aGVsbG8=', 'base64'))
+    assertFailure(T, 'aGV     sbG8=', ['Invalid value "aGV     sbG8=" supplied to : BufferFromBase64String'])
+    assertFailure(T, '!@#$%^', ['Invalid value "!@#$%^" supplied to : BufferFromBase64String'])
+  })
+  it('encode', () => {
+    assert.strictEqual(T.encode(Buffer.alloc(0)), '')
+    assert.strictEqual(T.encode(Buffer.from('aGVsbG8=', 'base64')), 'aGVsbG8=')
+  })
+})


### PR DESCRIPTION
Codec for decoding a base64 string into a NodeJS Buffer. Obviously this won't work when used in a browser context but i don't think its a breaking change as i wouldn't expect such a project to use it.