### PR TITLE
add withEncode function

### DIFF
--- a/docs/modules/withEncode.ts.md
+++ b/docs/modules/withEncode.ts.md
@@ -1,0 +1,48 @@
+---
+title: withEncode.ts
+nav_order: 26
+parent: Modules
+---
+
+# withEncode overview
+
+Added in v0.5.12
+
+---
+
+<h2 class="text-delta">Table of contents</h2>
+
+- [withEncode](#withencode)
+
+---
+
+# withEncode
+
+Returns a clone of the given codec which uses the given `encode` function
+
+**Signature**
+
+```ts
+export function withEncode<A, O, I, P>(
+  codec: t.Type<A, O, I>,
+  encode: (a: A) => P,
+  name: string = codec.name
+): t.Type<A, P, I> { ... }
+```
+
+**Example**
+
+```ts
+import { withEncode } from 'io-ts-types/lib/withEncode'
+import * as t from 'io-ts'
+import { PathReporter } from 'io-ts/lib/PathReporter'
+import { right } from 'fp-ts/lib/Either'
+
+const T = withEncode(t.number, String)
+
+assert.deepStrictEqual(T.decode(1), right(1))
+assert.deepStrictEqual(T.encode(1), '1')
+assert.deepStrictEqual(PathReporter.report(T.decode('str')), ['Invalid value "str" supplied to : number'])
+```
+
+Added in v0.5.12

--- a/docs/modules/withFallback.ts.md
+++ b/docs/modules/withFallback.ts.md
@@ -1,6 +1,6 @@
 ---
 title: withFallback.ts
-nav_order: 26
+nav_order: 27
 parent: Modules
 ---
 

--- a/docs/modules/withMessage.ts.md
+++ b/docs/modules/withMessage.ts.md
@@ -1,6 +1,6 @@
 ---
 title: withMessage.ts
-nav_order: 27
+nav_order: 28
 parent: Modules
 ---
 

--- a/docs/modules/withValidate.ts.md
+++ b/docs/modules/withValidate.ts.md
@@ -1,6 +1,6 @@
 ---
 title: withValidate.ts
-nav_order: 28
+nav_order: 29
 parent: Modules
 ---
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -132,3 +132,8 @@ export * from './either'
  * @since 0.5.11
  */
 export * from './BigIntFromString'
+
+/**
+ * @since 0.5.12
+ */
+export * from './withEncode'

--- a/src/withEncode.ts
+++ b/src/withEncode.ts
@@ -1,0 +1,29 @@
+/**
+ * @since 0.5.12
+ */
+import * as t from 'io-ts'
+
+/**
+ * Returns a clone of the given codec which uses the given `encode` function
+ *
+ * @example
+ * import { withEncode } from 'io-ts-types/lib/withEncode'
+ * import * as t from 'io-ts'
+ * import { PathReporter } from 'io-ts/lib/PathReporter'
+ * import { right } from 'fp-ts/lib/Either'
+ *
+ * const T = withEncode(t.number, String)
+ *
+ * assert.deepStrictEqual(T.decode(1), right(1))
+ * assert.deepStrictEqual(T.encode(1), '1')
+ * assert.deepStrictEqual(PathReporter.report(T.decode('str')), ['Invalid value "str" supplied to : number'])
+ *
+ * @since 0.5.12
+ */
+export function withEncode<A, O, I, P>(
+  codec: t.Type<A, O, I>,
+  encode: (a: A) => P,
+  name: string = codec.name
+): t.Type<A, P, I> {
+  return new t.Type(name, codec.is, codec.validate, encode)
+}

--- a/test/withEncode.ts
+++ b/test/withEncode.ts
@@ -1,0 +1,25 @@
+import * as t from 'io-ts'
+import * as assert from 'assert'
+import { withEncode } from '../src'
+import { assertSuccess, assertFailure } from './helpers'
+
+describe('withEncode', () => {
+  it('is', () => {
+    const T = withEncode(t.number, String)
+    assert.strictEqual(T.is(5), true)
+    assert.strictEqual(T.is(null), false)
+  })
+  it('decode', () => {
+    const T = withEncode(t.number, String, 'MyCodec')
+    assertSuccess(T.decode(0), 0)
+    assertSuccess(T.decode(10), 10)
+    assertSuccess(T.decode(-1), -1)
+    assertSuccess(T.decode(11), 11)
+    assertFailure(T, '', ['Invalid value "" supplied to : MyCodec'])
+    assertFailure(T, 'a', ['Invalid value "a" supplied to : MyCodec'])
+  })
+  it('encode', () => {
+    const T = withEncode(t.number, String)
+    assert.strictEqual(T.encode(5), '5')
+  })
+})


### PR DESCRIPTION
`withEncode` is similar to `withValidate`:

`withEncode` clones an existing codec and overrides the existing
`encode` function with the given `encode` function. This can be useful
when you want to use `t.type` to combinatorially create codecs but
want to leverage the `encode` function to encode into a different type.
