### PR TITLE
add `JsonFromString`, closes #153

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@
 **Note**: Gaps between patch versions are faulty/broken releases. **Note**: A feature tagged as Experimental is in a
 high state of flux, you're at risk of it changing without notice.
 
+# 0.5.14
+
+- **New Feature**
+  - add `JsonFromString`, closes #153 (@gcanti)
+
 # 0.5.13
 
 - **New Feature**

--- a/docs/modules/JsonFromString.ts.md
+++ b/docs/modules/JsonFromString.ts.md
@@ -15,7 +15,7 @@ Added in v0.5.14
 - [JsonArray (interface)](#jsonarray-interface)
 - [JsonRecord (interface)](#jsonrecord-interface)
 - [Json (type alias)](#json-type-alias)
-- [JSONFromString](#jsonfromstring)
+- [JsonFromString](#jsonfromstring)
 
 ---
 
@@ -53,12 +53,12 @@ export type Json = boolean | number | string | null | JsonArray | JsonRecord
 
 Added in v0.5.14
 
-# JSONFromString
+# JsonFromString
 
 **Signature**
 
 ```ts
-export const JSONFromString: t.Type<Json, string, string> = ...
+export const JsonFromString: t.Type<Json, string, string> = ...
 ```
 
 Added in v0.5.14

--- a/docs/modules/JsonFromString.ts.md
+++ b/docs/modules/JsonFromString.ts.md
@@ -1,0 +1,64 @@
+---
+title: JsonFromString.ts
+nav_order: 16
+parent: Modules
+---
+
+# JsonFromString overview
+
+Added in v0.5.14
+
+---
+
+<h2 class="text-delta">Table of contents</h2>
+
+- [JsonArray (interface)](#jsonarray-interface)
+- [JsonRecord (interface)](#jsonrecord-interface)
+- [Json (type alias)](#json-type-alias)
+- [JSONFromString](#jsonfromstring)
+
+---
+
+# JsonArray (interface)
+
+**Signature**
+
+```ts
+export interface JsonArray extends ReadonlyArray<Json> {}
+```
+
+Added in v0.5.14
+
+# JsonRecord (interface)
+
+**Signature**
+
+```ts
+export interface JsonRecord {
+  readonly [key: string]: Json
+}
+```
+
+Added in v0.5.14
+
+# Json (type alias)
+
+Copied from `fp-ts/Either` module.
+
+**Signature**
+
+```ts
+export type Json = boolean | number | string | null | JsonArray | JsonRecord
+```
+
+Added in v0.5.14
+
+# JSONFromString
+
+**Signature**
+
+```ts
+export const JSONFromString: t.Type<Json, string, string> = ...
+```
+
+Added in v0.5.14

--- a/docs/modules/NonEmptyString.ts.md
+++ b/docs/modules/NonEmptyString.ts.md
@@ -1,6 +1,6 @@
 ---
 title: NonEmptyString.ts
-nav_order: 18
+nav_order: 19
 parent: Modules
 ---
 

--- a/docs/modules/NumberFromString.ts.md
+++ b/docs/modules/NumberFromString.ts.md
@@ -1,6 +1,6 @@
 ---
 title: NumberFromString.ts
-nav_order: 19
+nav_order: 20
 parent: Modules
 ---
 

--- a/docs/modules/UUID.ts.md
+++ b/docs/modules/UUID.ts.md
@@ -1,6 +1,6 @@
 ---
 title: UUID.ts
-nav_order: 26
+nav_order: 27
 parent: Modules
 ---
 

--- a/docs/modules/mapOutput.ts.md
+++ b/docs/modules/mapOutput.ts.md
@@ -1,6 +1,6 @@
 ---
 title: mapOutput.ts
-nav_order: 16
+nav_order: 17
 parent: Modules
 ---
 

--- a/docs/modules/nonEmptyArray.ts.md
+++ b/docs/modules/nonEmptyArray.ts.md
@@ -1,6 +1,6 @@
 ---
 title: nonEmptyArray.ts
-nav_order: 17
+nav_order: 18
 parent: Modules
 ---
 

--- a/docs/modules/option.ts.md
+++ b/docs/modules/option.ts.md
@@ -1,6 +1,6 @@
 ---
 title: option.ts
-nav_order: 20
+nav_order: 21
 parent: Modules
 ---
 

--- a/docs/modules/optionFromNullable.ts.md
+++ b/docs/modules/optionFromNullable.ts.md
@@ -1,6 +1,6 @@
 ---
 title: optionFromNullable.ts
-nav_order: 21
+nav_order: 22
 parent: Modules
 ---
 

--- a/docs/modules/readonlyNonEmptyArray.ts.md
+++ b/docs/modules/readonlyNonEmptyArray.ts.md
@@ -1,6 +1,6 @@
 ---
 title: readonlyNonEmptyArray.ts
-nav_order: 22
+nav_order: 23
 parent: Modules
 ---
 

--- a/docs/modules/readonlySetFromArray.ts.md
+++ b/docs/modules/readonlySetFromArray.ts.md
@@ -1,6 +1,6 @@
 ---
 title: readonlySetFromArray.ts
-nav_order: 23
+nav_order: 24
 parent: Modules
 ---
 

--- a/docs/modules/regexp.ts.md
+++ b/docs/modules/regexp.ts.md
@@ -1,6 +1,6 @@
 ---
 title: regexp.ts
-nav_order: 24
+nav_order: 25
 parent: Modules
 ---
 

--- a/docs/modules/setFromArray.ts.md
+++ b/docs/modules/setFromArray.ts.md
@@ -1,6 +1,6 @@
 ---
 title: setFromArray.ts
-nav_order: 25
+nav_order: 26
 parent: Modules
 ---
 

--- a/docs/modules/withEncode.ts.md
+++ b/docs/modules/withEncode.ts.md
@@ -1,6 +1,6 @@
 ---
 title: withEncode.ts
-nav_order: 27
+nav_order: 28
 parent: Modules
 ---
 

--- a/docs/modules/withFallback.ts.md
+++ b/docs/modules/withFallback.ts.md
@@ -1,6 +1,6 @@
 ---
 title: withFallback.ts
-nav_order: 28
+nav_order: 29
 parent: Modules
 ---
 

--- a/docs/modules/withMessage.ts.md
+++ b/docs/modules/withMessage.ts.md
@@ -1,6 +1,6 @@
 ---
 title: withMessage.ts
-nav_order: 29
+nav_order: 30
 parent: Modules
 ---
 

--- a/docs/modules/withValidate.ts.md
+++ b/docs/modules/withValidate.ts.md
@@ -1,6 +1,6 @@
 ---
 title: withValidate.ts
-nav_order: 30
+nav_order: 31
 parent: Modules
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "io-ts-types",
-  "version": "0.5.13",
+  "version": "0.5.14",
   "description": "A collection of codecs and combinators for use with io-ts",
   "main": "lib/index.js",
   "module": "es6/index.js",

--- a/src/JsonFromString.ts
+++ b/src/JsonFromString.ts
@@ -29,8 +29,8 @@ const Json: t.Type<Json> = t.union([t.boolean, t.number, t.string, t.null, JsonA
 /**
  * @since 0.5.14
  */
-export const JSONFromString = new t.Type<Json, string, string>(
-  'JSONFromString',
+export const JsonFromString = new t.Type<Json, string, string>(
+  'JsonFromString',
   Json.is,
   (s, c) => {
     try {

--- a/src/JsonFromString.ts
+++ b/src/JsonFromString.ts
@@ -1,0 +1,43 @@
+/**
+ * @since 0.5.14
+ */
+import * as t from 'io-ts'
+
+/**
+ * Copied from `fp-ts/Either` module.
+ *
+ * @since 0.5.14
+ */
+export type Json = boolean | number | string | null | JsonArray | JsonRecord
+
+/**
+ * @since 0.5.14
+ */
+export interface JsonRecord {
+  readonly [key: string]: Json
+}
+
+/**
+ * @since 0.5.14
+ */
+export interface JsonArray extends ReadonlyArray<Json> {}
+
+const JsonArray: t.Type<JsonArray> = t.recursion('JsonArray', () => t.readonlyArray(Json))
+const JsonRecord: t.Type<JsonRecord> = t.recursion('JsonRecord', () => t.record(t.string, Json))
+const Json: t.Type<Json> = t.union([t.boolean, t.number, t.string, t.null, JsonArray, JsonRecord], 'Json')
+
+/**
+ * @since 0.5.14
+ */
+export const JSONFromString = new t.Type<Json, string, string>(
+  'JSONFromString',
+  Json.is,
+  (s, c) => {
+    try {
+      return t.success(JSON.parse(s))
+    } catch (e) {
+      return t.failure(s, c)
+    }
+  },
+  json => JSON.stringify(json)
+)

--- a/src/index.ts
+++ b/src/index.ts
@@ -124,6 +124,11 @@ export * from './setFromArray'
 export * from './IntFromString'
 
 /**
+ * @since 0.5.14
+ */
+export * from './JsonFromString'
+
+/**
  * @since 0.5.8
  */
 export * from './either'

--- a/test/JsonFromString.ts
+++ b/test/JsonFromString.ts
@@ -1,23 +1,24 @@
 import * as assert from 'assert'
-import { JSONFromString } from '../src'
+import { JsonFromString } from '../src'
 import { assertFailure, assertSuccess } from './helpers'
 
 describe('JSONFromString', () => {
   it('is', () => {
-    assert.deepStrictEqual(JSONFromString.is(null), true)
-    assert.deepStrictEqual(JSONFromString.is('a'), true)
-    assert.deepStrictEqual(JSONFromString.is(1), true)
-    assert.deepStrictEqual(JSONFromString.is(true), true)
-    assert.deepStrictEqual(JSONFromString.is(false), true)
-    assert.deepStrictEqual(JSONFromString.is([]), true)
-    assert.deepStrictEqual(JSONFromString.is([1]), true)
-    assert.deepStrictEqual(JSONFromString.is({}), true)
-    assert.deepStrictEqual(JSONFromString.is({ a: 1 }), true)
-    assert.deepStrictEqual(JSONFromString.is({ a: Date }), false)
+    const T = JsonFromString
+    assert.deepStrictEqual(T.is(null), true)
+    assert.deepStrictEqual(T.is('a'), true)
+    assert.deepStrictEqual(T.is(1), true)
+    assert.deepStrictEqual(T.is(true), true)
+    assert.deepStrictEqual(T.is(false), true)
+    assert.deepStrictEqual(T.is([]), true)
+    assert.deepStrictEqual(T.is([1]), true)
+    assert.deepStrictEqual(T.is({}), true)
+    assert.deepStrictEqual(T.is({ a: 1 }), true)
+    assert.deepStrictEqual(T.is({ a: Date }), false)
   })
 
   it('decode', () => {
-    const T = JSONFromString
+    const T = JsonFromString
     assertSuccess(T.decode('null'), null)
     assertSuccess(T.decode('1'), 1)
     assertSuccess(T.decode('"a"'), 'a')
@@ -25,12 +26,12 @@ describe('JSONFromString', () => {
     assertSuccess(T.decode('false'), false)
     assertSuccess(T.decode('[]'), [])
     assertSuccess(T.decode('{}'), {})
-    assertFailure(T, '{', ['Invalid value "{" supplied to : JSONFromString'])
-    assertFailure(T, '{"a":undefined}', ['Invalid value "{\\"a\\":undefined}" supplied to : JSONFromString'])
+    assertFailure(T, '{', ['Invalid value "{" supplied to : JsonFromString'])
+    assertFailure(T, '{"a":undefined}', ['Invalid value "{\\"a\\":undefined}" supplied to : JsonFromString'])
   })
 
   it('encode', () => {
-    const T = JSONFromString
+    const T = JsonFromString
     assert.deepEqual(T.encode({}), '{}')
   })
 })

--- a/test/JsonFromString.ts
+++ b/test/JsonFromString.ts
@@ -1,0 +1,36 @@
+import * as assert from 'assert'
+import { JSONFromString } from '../src'
+import { assertFailure, assertSuccess } from './helpers'
+
+describe('JSONFromString', () => {
+  it('is', () => {
+    assert.deepStrictEqual(JSONFromString.is(null), true)
+    assert.deepStrictEqual(JSONFromString.is('a'), true)
+    assert.deepStrictEqual(JSONFromString.is(1), true)
+    assert.deepStrictEqual(JSONFromString.is(true), true)
+    assert.deepStrictEqual(JSONFromString.is(false), true)
+    assert.deepStrictEqual(JSONFromString.is([]), true)
+    assert.deepStrictEqual(JSONFromString.is([1]), true)
+    assert.deepStrictEqual(JSONFromString.is({}), true)
+    assert.deepStrictEqual(JSONFromString.is({ a: 1 }), true)
+    assert.deepStrictEqual(JSONFromString.is({ a: Date }), false)
+  })
+
+  it('decode', () => {
+    const T = JSONFromString
+    assertSuccess(T.decode('null'), null)
+    assertSuccess(T.decode('1'), 1)
+    assertSuccess(T.decode('"a"'), 'a')
+    assertSuccess(T.decode('true'), true)
+    assertSuccess(T.decode('false'), false)
+    assertSuccess(T.decode('[]'), [])
+    assertSuccess(T.decode('{}'), {})
+    assertFailure(T, '{', ['Invalid value "{" supplied to : JSONFromString'])
+    assertFailure(T, '{"a":undefined}', ['Invalid value "{\\"a\\":undefined}" supplied to : JSONFromString'])
+  })
+
+  it('encode', () => {
+    const T = JSONFromString
+    assert.deepEqual(T.encode({}), '{}')
+  })
+})


### PR DESCRIPTION
@OliverJAsh I need to copy `Json` from the `fp-ts/Either` module though, because the `Json` type was added to `fp-ts` in v2.6.7 and the peer dependency of this package is `"fp-ts": "^2.0.0"`