### PR TITLE
Fix DateFromUnixTime.encode returning a floating point number

### DIFF
--- a/src/DateFromUnixTime.ts
+++ b/src/DateFromUnixTime.ts
@@ -32,5 +32,5 @@ export const DateFromUnixTime: DateFromUnixTimeC = new t.Type<Date, number, unkn
         return isNaN(d.getTime()) ? t.failure(u, c) : t.success(d)
       })
     ),
-  a => a.getTime() / 1000
+  a => Math.floor(a.getTime() / 1000)
 )

--- a/test/DateFromUnixTime.ts
+++ b/test/DateFromUnixTime.ts
@@ -3,9 +3,8 @@ import { DateFromUnixTime } from '../src'
 import { assertSuccess, assertFailure } from './helpers'
 import { either } from 'fp-ts/lib/Either'
 
-const d = new Date(1973, 10, 30)
-const n = d.getTime()
-const seconds = n / 1000
+const d = new Date(1973, 10, 30, 12, 12, 12, 12)
+const seconds = Math.floor(d.getTime() / 1000)
 
 describe('DateFromUnixTime', () => {
   it('is', () => {
@@ -16,8 +15,8 @@ describe('DateFromUnixTime', () => {
 
   it('decode', () => {
     const T = DateFromUnixTime
-    assertSuccess(T.decode(seconds), d)
-    assertSuccess(either.map(T.decode(seconds), d => d.getTime()), n)
+    assertSuccess(T.decode(seconds), new Date(seconds * 1000))
+    assertSuccess(either.map(T.decode(seconds), d => d.getTime()), seconds * 1000)
     assertFailure(T, NaN, ['Invalid value NaN supplied to : DateFromUnixTime'])
     assertFailure(T, '', ['Invalid value "" supplied to : DateFromUnixTime'])
     assertFailure(T, 1.2345678901234568e79, ['Invalid value 1.2345678901234568e+79 supplied to : DateFromUnixTime'])


### PR DESCRIPTION
This solves #159 and I also figured out why the tests didn't catch this and updated them. The date used for testing did not include any hours/mins/secs/etc so this slipped through. 

All tests pass except for some type-level tests which I can only assume must have failed previously? 

```

Running type-level tests for the following versions: ["3.5","3.6","3.7","3.8","3.9","4.0","4.1","4.2"]
Error: /home/sbrg/mess/io-ts-types/dtslint/ts3.5/readonlyNonEmptyArray.ts:6:1
ERROR: 6:1  expect  Expected type to be:
  (i: unknown) => Either<Errors, ReadonlyNonEmptyArray<string>>
got:
  (i: unknown) => Validation<ReadonlyNonEmptyArray<string>>

/home/sbrg/mess/io-ts-types/dtslint/ts3.5/readonlySetFromArray.ts:7:1
ERROR: 7:1  expect  Expected type to be:
  (i: unknown) => Either<Errors, ReadonlySet<string>>
got:
  (i: unknown) => Validation<ReadonlySet<string>>

```