### PR TITLE
Add error message to JsonFromString

### DIFF
--- a/src/JsonFromString.ts
+++ b/src/JsonFromString.ts
@@ -47,6 +47,9 @@ export const JsonFromString = new t.Type<Json, string, string>(
     try {
       return t.success(JSON.parse(s))
     } catch (e) {
+      if (e instanceof Error) {
+        return t.failure(s, c, e.message)
+      }
       return t.failure(s, c)
     }
   },

--- a/test/JsonFromString.ts
+++ b/test/JsonFromString.ts
@@ -27,8 +27,8 @@ describe('JSONFromString', () => {
     assertSuccess(T.decode('false'), false)
     assertSuccess(T.decode('[]'), [])
     assertSuccess(T.decode('{}'), {})
-    assertFailure(T, '{', ['Invalid value "{" supplied to : JsonFromString'])
-    assertFailure(T, '{"a":undefined}', ['Invalid value "{\\"a\\":undefined}" supplied to : JsonFromString'])
+    assertFailure(T, '{', ['Unexpected end of JSON input'])
+    assertFailure(T, '{"a":undefined}', ['Unexpected token u in JSON at position 5'])
   })
 
   it('encode', () => {


### PR DESCRIPTION
Hello ! I added the the error message from `JSON.parse` in `JsonFromString`. Maybe it's not the right way to add it, but I think it might be useful somewhere. Let me know :) 