### PR TITLE
feat: add `URLFromString`

### DIFF
--- a/docs/modules/URLFromString.ts.md
+++ b/docs/modules/URLFromString.ts.md
@@ -1,0 +1,54 @@
+---
+title: URLFromString.ts
+nav_order: 27
+parent: Modules
+---
+
+# URLFromString overview
+
+Added in v0.5.17
+
+---
+
+<h2 class="text-delta">Table of contents</h2>
+
+- [URLFromStringC (interface)](#urlfromstringc-interface)
+- [URLFromString](#urlfromstring)
+
+---
+
+# URLFromStringC (interface)
+
+**Signature**
+
+```ts
+export interface URLFromStringC extends t.Type<URL, string, unknown> {}
+```
+
+Added in v0.5.17
+
+# URLFromString
+
+**Signature**
+
+```ts
+export const URLFromString: URLFromStringC = ...
+```
+
+**Example**
+
+```ts
+import { URLFromString } from 'io-ts-types/lib/URLFromString'
+import { right } from 'fp-ts/lib/Either'
+import { PathReporter } from 'io-ts/lib/PathReporter'
+
+assert.deepStrictEqual(
+  URLFromString.decode('https://gcanti.github.io/io-ts-types/'),
+  right(new URL('https://gcanti.github.io/io-ts-types/'))
+)
+assert.deepStrictEqual(PathReporter.report(URLFromString.decode('/djulio')), [
+  'Invalid value "/djulio" supplied to : URLFromString'
+])
+```
+
+Added in v0.5.17

--- a/docs/modules/URLFromString.ts.md
+++ b/docs/modules/URLFromString.ts.md
@@ -22,7 +22,7 @@ Added in v0.5.17
 **Signature**
 
 ```ts
-export interface URLFromStringC extends t.Type<URL, string, unknown> {}
+export interface URLFromStringC extends t.Type<typeof URL, string, unknown> {}
 ```
 
 Added in v0.5.17

--- a/docs/modules/UUID.ts.md
+++ b/docs/modules/UUID.ts.md
@@ -1,6 +1,6 @@
 ---
 title: UUID.ts
-nav_order: 27
+nav_order: 28
 parent: Modules
 ---
 

--- a/docs/modules/withEncode.ts.md
+++ b/docs/modules/withEncode.ts.md
@@ -1,6 +1,6 @@
 ---
 title: withEncode.ts
-nav_order: 28
+nav_order: 29
 parent: Modules
 ---
 

--- a/docs/modules/withFallback.ts.md
+++ b/docs/modules/withFallback.ts.md
@@ -1,6 +1,6 @@
 ---
 title: withFallback.ts
-nav_order: 29
+nav_order: 30
 parent: Modules
 ---
 

--- a/docs/modules/withMessage.ts.md
+++ b/docs/modules/withMessage.ts.md
@@ -1,6 +1,6 @@
 ---
 title: withMessage.ts
-nav_order: 30
+nav_order: 31
 parent: Modules
 ---
 

--- a/docs/modules/withValidate.ts.md
+++ b/docs/modules/withValidate.ts.md
@@ -1,6 +1,6 @@
 ---
 title: withValidate.ts
-nav_order: 31
+nav_order: 32
 parent: Modules
 ---
 

--- a/src/URLFromString.ts
+++ b/src/URLFromString.ts
@@ -4,10 +4,8 @@
 import * as t from 'io-ts'
 import { pipe } from 'fp-ts/lib/pipeable'
 import { chain } from 'fp-ts/lib/Either'
-import * as nodeURL from 'url'
 
-declare const window: any // tslint:disable-next-line
-/* istanbul ignore next */ const URL = typeof window === 'undefined' ? nodeURL.URL : window.URL
+declare const URL: any
 
 /**
  * @since 0.5.17

--- a/src/URLFromString.ts
+++ b/src/URLFromString.ts
@@ -4,6 +4,7 @@
 import * as t from 'io-ts'
 import { pipe } from 'fp-ts/lib/pipeable'
 import { chain } from 'fp-ts/lib/Either'
+import { URL } from 'url'
 
 /**
  * @since 0.5.17
@@ -15,10 +16,10 @@ export interface URLFromStringC extends t.Type<URL, string, unknown> {}
  * import { URLFromString } from 'io-ts-types/lib/url'
  * import { right } from 'fp-ts/lib/Either'
  * import { PathReporter } from 'io-ts/lib/PathReporter'
- * 
+ *
  * assert.deepStrictEqual(URLFromString.decode('https://gcanti.github.io/io-ts-types/'), right(new URL('https://gcanti.github.io/io-ts-types/')))
- * assert.deepStrictEqual(PathReporter.report(URLFromString.decode('/djulio')), ['Invalid value "/djulio" supplied to : url'])
- * 
+ * assert.deepStrictEqual(PathReporter.report(URLFromString.decode('/djulio')), ['Invalid value "/djulio" supplied to : URLFromString'])
+ *
  *
  * @since 0.5.17
  */

--- a/src/URLFromString.ts
+++ b/src/URLFromString.ts
@@ -1,0 +1,40 @@
+/**
+ * @since 0.5.17
+ */
+import * as t from 'io-ts'
+import { pipe } from 'fp-ts/lib/pipeable'
+import { chain } from 'fp-ts/lib/Either'
+
+/**
+ * @since 0.5.17
+ */
+export interface URLFromStringC extends t.Type<URL, string, unknown> {}
+
+/**
+ * @example
+ * import { URLFromString } from 'io-ts-types/lib/url'
+ * import { right } from 'fp-ts/lib/Either'
+ * import { PathReporter } from 'io-ts/lib/PathReporter'
+ * 
+ * assert.deepStrictEqual(URLFromString.decode('https://gcanti.github.io/io-ts-types/'), right(new URL('https://gcanti.github.io/io-ts-types/')))
+ * assert.deepStrictEqual(PathReporter.report(URLFromString.decode('/djulio')), ['Invalid value "/djulio" supplied to : url'])
+ * 
+ *
+ * @since 0.5.17
+ */
+export const URLFromString: URLFromStringC = new t.Type<URL, string, unknown>(
+  'URLFromString',
+  (u): u is URL => u instanceof URL,
+  (u, c) =>
+    pipe(
+      t.string.validate(u, c),
+      chain(s => {
+        try {
+          return t.success(new URL(s))
+        } catch (error) {
+          return t.failure(u, c)
+        }
+      })
+    ),
+  String
+)

--- a/src/URLFromString.ts
+++ b/src/URLFromString.ts
@@ -4,12 +4,15 @@
 import * as t from 'io-ts'
 import { pipe } from 'fp-ts/lib/pipeable'
 import { chain } from 'fp-ts/lib/Either'
-import { URL } from 'url'
+import * as nodeURL from 'url'
+
+declare const window: any // tslint:disable-next-line
+/* istanbul ignore next */ const URL = typeof window === 'undefined' ? nodeURL.URL : window.URL
 
 /**
  * @since 0.5.17
  */
-export interface URLFromStringC extends t.Type<URL, string, unknown> {}
+export interface URLFromStringC extends t.Type<typeof URL, string, unknown> {}
 
 /**
  * @example
@@ -23,9 +26,9 @@ export interface URLFromStringC extends t.Type<URL, string, unknown> {}
  *
  * @since 0.5.17
  */
-export const URLFromString: URLFromStringC = new t.Type<URL, string, unknown>(
+export const URLFromString: URLFromStringC = new t.Type<typeof URL, string, unknown>(
   'URLFromString',
-  (u): u is URL => u instanceof URL,
+  (u): u is typeof URL => u instanceof URL,
   (u, c) =>
     pipe(
       t.string.validate(u, c),

--- a/src/URLFromString.ts
+++ b/src/URLFromString.ts
@@ -13,7 +13,7 @@ export interface URLFromStringC extends t.Type<URL, string, unknown> {}
 
 /**
  * @example
- * import { URLFromString } from 'io-ts-types/lib/url'
+ * import { URLFromString } from 'io-ts-types/lib/URLFromString'
  * import { right } from 'fp-ts/lib/Either'
  * import { PathReporter } from 'io-ts/lib/PathReporter'
  *

--- a/src/index.ts
+++ b/src/index.ts
@@ -147,3 +147,8 @@ export * from './withEncode'
  * @since 0.5.13
  */
 export * from './BooleanFromNumber'
+
+/**
+ * @since 0.5.17
+ */
+ export * from './URLFromString'

--- a/src/index.ts
+++ b/src/index.ts
@@ -151,4 +151,4 @@ export * from './BooleanFromNumber'
 /**
  * @since 0.5.17
  */
- export * from './URLFromString'
+export * from './URLFromString'

--- a/test/URLFromString.ts
+++ b/test/URLFromString.ts
@@ -20,6 +20,9 @@ describe('BigIntFromString', () => {
   })
   it('encode', () => {
     const T = URLFromString
-    assert.deepStrictEqual(T.encode(new URL('https://gcanti.github.io/io-ts-types/')), 'https://gcanti.github.io/io-ts-types/')
+    assert.deepStrictEqual(
+      T.encode(new URL('https://gcanti.github.io/io-ts-types/')),
+      'https://gcanti.github.io/io-ts-types/'
+    )
   })
 })

--- a/test/URLFromString.ts
+++ b/test/URLFromString.ts
@@ -1,0 +1,25 @@
+import * as assert from 'assert'
+import { URL } from 'url'
+import { URLFromString } from '../src'
+import { assertFailure, assertSuccess } from './helpers'
+
+describe('BigIntFromString', () => {
+  it('is', () => {
+    const T = URLFromString
+    assert.strictEqual(T.is(new URL('https://gcanti.github.io/io-ts-types/')), true)
+    assert.strictEqual(T.is(new URL('ftp://gcanti.github.io/io-ts-types/')), true)
+    assert.strictEqual(T.is(''), false)
+    assert.strictEqual(T.is('/djulio'), false)
+    assert.strictEqual(T.is(null), false)
+  })
+  it('decode', () => {
+    const T = URLFromString
+    assertSuccess(T.decode('https://gcanti.github.io/io-ts-types/'), new URL('https://gcanti.github.io/io-ts-types/'))
+    assertFailure(T, '/djulio', ['Invalid value "/djulio" supplied to : URLFromString'])
+    assertFailure(T, '', ['Invalid value "" supplied to : URLFromString'])
+  })
+  it('encode', () => {
+    const T = URLFromString
+    assert.deepStrictEqual(T.encode(new URL('https://gcanti.github.io/io-ts-types/')), 'https://gcanti.github.io/io-ts-types/')
+  })
+})


### PR DESCRIPTION
Simply add a URLFromString codec. It takes a string and uses the native URL api to detect if it's valid.

Note: I reference version 0.5.17 in the doc string, but I haven't bumped the version anywhere, I'm not aware of the preferred publish strategy