### PR TITLE
add `ArrayFromString` codec

### DIFF
--- a/docs/modules/ArrayFromString.ts.md
+++ b/docs/modules/ArrayFromString.ts.md
@@ -1,0 +1,54 @@
+---
+title: ArrayFromString.ts
+nav_order: 1
+parent: Modules
+---
+
+# ArrayFromString overview
+
+Added in v0.5.17
+
+---
+
+<h2 class="text-delta">Table of contents</h2>
+
+- [ArrayFromStringC (interface)](#arrayfromstringc-interface)
+- [ArrayFromString](#arrayfromstring)
+
+---
+
+# ArrayFromStringC (interface)
+
+**Signature**
+
+```ts
+export interface ArrayFromStringC<C extends t.Mixed> extends t.Type<Array<t.TypeOf<C>>, string, unknown> {}
+```
+
+Added in v0.5.17
+
+# ArrayFromString
+
+**Signature**
+
+```ts
+export function ArrayFromString<C extends t.Mixed>(
+  codec: C,
+  decoderSeparator: string | RegExp = '',
+  encoderSeparator = '',
+  name = `ArrayFromString<${codec.name}>`
+): ArrayFromStringC<C> { ... }
+```
+
+**Example**
+
+```ts
+import { ArrayFromString } from 'io-ts-types/lib/ArrayFromString'
+import { NumberFromString } from 'io-ts-types/lib/NumberFromString'
+import { right } from 'fp-ts/lib/Either'
+
+assert.deepStrictEqual(ArrayFromString(NumberFromString, ',').decode('1,2,3'), right([1, 2, 3]))
+assert.deepStrictEqual(ArrayFromString(NumberFromString, /[\s,]+/).decode('1, 2, 3'), right([1, 2, 3]))
+```
+
+Added in v0.5.17

--- a/docs/modules/ArrayFromString.ts.md
+++ b/docs/modules/ArrayFromString.ts.md
@@ -22,7 +22,7 @@ Added in v0.5.17
 **Signature**
 
 ```ts
-export interface ArrayFromStringC<C extends t.Mixed> extends t.Type<Array<t.TypeOf<C>>, string, unknown> {}
+export interface ArrayFromStringC<C extends t.Type<any, string>> extends t.Type<Array<t.TypeOf<C>>, string> {}
 ```
 
 Added in v0.5.17
@@ -32,7 +32,7 @@ Added in v0.5.17
 **Signature**
 
 ```ts
-export function ArrayFromString<C extends t.Mixed>(
+export function ArrayFromString<C extends t.Type<any, string>>(
   codec: C,
   decoderSeparator: string | RegExp = '',
   encoderSeparator = '',

--- a/docs/modules/BigIntFromString.ts.md
+++ b/docs/modules/BigIntFromString.ts.md
@@ -1,6 +1,6 @@
 ---
 title: BigIntFromString.ts
-nav_order: 1
+nav_order: 2
 parent: Modules
 ---
 

--- a/docs/modules/BooleanFromNumber.ts.md
+++ b/docs/modules/BooleanFromNumber.ts.md
@@ -1,6 +1,6 @@
 ---
 title: BooleanFromNumber.ts
-nav_order: 2
+nav_order: 3
 parent: Modules
 ---
 

--- a/docs/modules/BooleanFromString.ts.md
+++ b/docs/modules/BooleanFromString.ts.md
@@ -1,6 +1,6 @@
 ---
 title: BooleanFromString.ts
-nav_order: 3
+nav_order: 4
 parent: Modules
 ---
 

--- a/docs/modules/DateFromISOString.ts.md
+++ b/docs/modules/DateFromISOString.ts.md
@@ -1,6 +1,6 @@
 ---
 title: DateFromISOString.ts
-nav_order: 6
+nav_order: 7
 parent: Modules
 ---
 

--- a/docs/modules/DateFromNumber.ts.md
+++ b/docs/modules/DateFromNumber.ts.md
@@ -1,6 +1,6 @@
 ---
 title: DateFromNumber.ts
-nav_order: 7
+nav_order: 8
 parent: Modules
 ---
 

--- a/docs/modules/DateFromUnixTime.ts.md
+++ b/docs/modules/DateFromUnixTime.ts.md
@@ -1,6 +1,6 @@
 ---
 title: DateFromUnixTime.ts
-nav_order: 8
+nav_order: 9
 parent: Modules
 ---
 

--- a/docs/modules/IntFromString.ts.md
+++ b/docs/modules/IntFromString.ts.md
@@ -1,6 +1,6 @@
 ---
 title: IntFromString.ts
-nav_order: 15
+nav_order: 16
 parent: Modules
 ---
 

--- a/docs/modules/JsonFromString.ts.md
+++ b/docs/modules/JsonFromString.ts.md
@@ -1,6 +1,6 @@
 ---
 title: JsonFromString.ts
-nav_order: 16
+nav_order: 17
 parent: Modules
 ---
 

--- a/docs/modules/NonEmptyString.ts.md
+++ b/docs/modules/NonEmptyString.ts.md
@@ -1,6 +1,6 @@
 ---
 title: NonEmptyString.ts
-nav_order: 19
+nav_order: 20
 parent: Modules
 ---
 

--- a/docs/modules/NumberFromString.ts.md
+++ b/docs/modules/NumberFromString.ts.md
@@ -1,6 +1,6 @@
 ---
 title: NumberFromString.ts
-nav_order: 20
+nav_order: 21
 parent: Modules
 ---
 

--- a/docs/modules/UUID.ts.md
+++ b/docs/modules/UUID.ts.md
@@ -1,6 +1,6 @@
 ---
 title: UUID.ts
-nav_order: 27
+nav_order: 28
 parent: Modules
 ---
 

--- a/docs/modules/clone.ts.md
+++ b/docs/modules/clone.ts.md
@@ -1,6 +1,6 @@
 ---
 title: clone.ts
-nav_order: 4
+nav_order: 5
 parent: Modules
 ---
 

--- a/docs/modules/date.ts.md
+++ b/docs/modules/date.ts.md
@@ -1,6 +1,6 @@
 ---
 title: date.ts
-nav_order: 5
+nav_order: 6
 parent: Modules
 ---
 

--- a/docs/modules/either.ts.md
+++ b/docs/modules/either.ts.md
@@ -1,6 +1,6 @@
 ---
 title: either.ts
-nav_order: 9
+nav_order: 10
 parent: Modules
 ---
 

--- a/docs/modules/fromNewtype.ts.md
+++ b/docs/modules/fromNewtype.ts.md
@@ -1,6 +1,6 @@
 ---
 title: fromNewtype.ts
-nav_order: 10
+nav_order: 11
 parent: Modules
 ---
 

--- a/docs/modules/fromNullable.ts.md
+++ b/docs/modules/fromNullable.ts.md
@@ -1,6 +1,6 @@
 ---
 title: fromNullable.ts
-nav_order: 11
+nav_order: 12
 parent: Modules
 ---
 

--- a/docs/modules/fromRefinement.ts.md
+++ b/docs/modules/fromRefinement.ts.md
@@ -1,6 +1,6 @@
 ---
 title: fromRefinement.ts
-nav_order: 12
+nav_order: 13
 parent: Modules
 ---
 

--- a/docs/modules/getLenses.ts.md
+++ b/docs/modules/getLenses.ts.md
@@ -1,6 +1,6 @@
 ---
 title: getLenses.ts
-nav_order: 13
+nav_order: 14
 parent: Modules
 ---
 

--- a/docs/modules/index.ts.md
+++ b/docs/modules/index.ts.md
@@ -1,6 +1,6 @@
 ---
 title: index.ts
-nav_order: 14
+nav_order: 15
 parent: Modules
 ---
 

--- a/docs/modules/mapOutput.ts.md
+++ b/docs/modules/mapOutput.ts.md
@@ -1,6 +1,6 @@
 ---
 title: mapOutput.ts
-nav_order: 17
+nav_order: 18
 parent: Modules
 ---
 

--- a/docs/modules/nonEmptyArray.ts.md
+++ b/docs/modules/nonEmptyArray.ts.md
@@ -1,6 +1,6 @@
 ---
 title: nonEmptyArray.ts
-nav_order: 18
+nav_order: 19
 parent: Modules
 ---
 

--- a/docs/modules/option.ts.md
+++ b/docs/modules/option.ts.md
@@ -1,6 +1,6 @@
 ---
 title: option.ts
-nav_order: 21
+nav_order: 22
 parent: Modules
 ---
 

--- a/docs/modules/optionFromNullable.ts.md
+++ b/docs/modules/optionFromNullable.ts.md
@@ -1,6 +1,6 @@
 ---
 title: optionFromNullable.ts
-nav_order: 22
+nav_order: 23
 parent: Modules
 ---
 

--- a/docs/modules/readonlyNonEmptyArray.ts.md
+++ b/docs/modules/readonlyNonEmptyArray.ts.md
@@ -1,6 +1,6 @@
 ---
 title: readonlyNonEmptyArray.ts
-nav_order: 23
+nav_order: 24
 parent: Modules
 ---
 

--- a/docs/modules/readonlySetFromArray.ts.md
+++ b/docs/modules/readonlySetFromArray.ts.md
@@ -1,6 +1,6 @@
 ---
 title: readonlySetFromArray.ts
-nav_order: 24
+nav_order: 25
 parent: Modules
 ---
 

--- a/docs/modules/regexp.ts.md
+++ b/docs/modules/regexp.ts.md
@@ -1,6 +1,6 @@
 ---
 title: regexp.ts
-nav_order: 25
+nav_order: 26
 parent: Modules
 ---
 

--- a/docs/modules/setFromArray.ts.md
+++ b/docs/modules/setFromArray.ts.md
@@ -1,6 +1,6 @@
 ---
 title: setFromArray.ts
-nav_order: 26
+nav_order: 27
 parent: Modules
 ---
 

--- a/docs/modules/withEncode.ts.md
+++ b/docs/modules/withEncode.ts.md
@@ -1,6 +1,6 @@
 ---
 title: withEncode.ts
-nav_order: 28
+nav_order: 29
 parent: Modules
 ---
 

--- a/docs/modules/withFallback.ts.md
+++ b/docs/modules/withFallback.ts.md
@@ -1,6 +1,6 @@
 ---
 title: withFallback.ts
-nav_order: 29
+nav_order: 30
 parent: Modules
 ---
 

--- a/docs/modules/withMessage.ts.md
+++ b/docs/modules/withMessage.ts.md
@@ -1,6 +1,6 @@
 ---
 title: withMessage.ts
-nav_order: 30
+nav_order: 31
 parent: Modules
 ---
 

--- a/docs/modules/withValidate.ts.md
+++ b/docs/modules/withValidate.ts.md
@@ -1,6 +1,6 @@
 ---
 title: withValidate.ts
-nav_order: 31
+nav_order: 32
 parent: Modules
 ---
 

--- a/src/ArrayFromString.ts
+++ b/src/ArrayFromString.ts
@@ -8,7 +8,7 @@ import { chain } from 'fp-ts/lib/Either'
 /**
  * @since 0.5.17
  */
-export interface ArrayFromStringC<C extends t.Mixed> extends t.Type<Array<t.TypeOf<C>>, string, unknown> {}
+export interface ArrayFromStringC<C extends t.Type<any, string>> extends t.Type<Array<t.TypeOf<C>>, string> {}
 
 /**
  * @example
@@ -20,14 +20,14 @@ export interface ArrayFromStringC<C extends t.Mixed> extends t.Type<Array<t.Type
  * assert.deepStrictEqual(ArrayFromString(NumberFromString, /[\s,]+/).decode("1, 2, 3"), right([1,2,3]))
  * @since 0.5.17
  */
-export function ArrayFromString<C extends t.Mixed>(
+export function ArrayFromString<C extends t.Type<any, string>>(
   codec: C,
   decoderSeparator: string | RegExp = '',
   encoderSeparator = '',
   name = `ArrayFromString<${codec.name}>`
 ): ArrayFromStringC<C> {
   const arr = t.array(codec)
-  return new t.Type<Array<t.TypeOf<C>>, string, unknown>(
+  return new t.Type<Array<t.TypeOf<C>>, string>(
     name,
     arr.is,
     (u, c) =>

--- a/src/ArrayFromString.ts
+++ b/src/ArrayFromString.ts
@@ -35,6 +35,6 @@ export function ArrayFromString<C extends t.Mixed>(
         t.string.validate(u, c),
         chain(str => arr.validate(str.split(decoderSeparator), c))
       ),
-    (a: Array<t.TypeOf<C>>) => arr.encode(a).join(encoderSeparator)
+    a => arr.encode(a).join(encoderSeparator)
   )
 }

--- a/src/ArrayFromString.ts
+++ b/src/ArrayFromString.ts
@@ -1,0 +1,47 @@
+/**
+ * @since 0.5.17
+ */
+import * as t from 'io-ts'
+import { pipe } from 'fp-ts/lib/pipeable'
+import { map, Traversable } from 'fp-ts/lib/Array'
+import { chain, Applicative } from 'fp-ts/lib/Either'
+
+/**
+ * @since 0.5.17
+ */
+export interface ArrayFromStringC<C extends t.Mixed> extends t.Type<Array<t.TypeOf<C>>, string, unknown> {}
+
+/**
+ * @example
+ * import { ArrayFromString } from 'io-ts-types/lib/ArrayFromString'
+ * import { NumberFromString } from 'io-ts-types/lib/NumberFromString'
+ * import { right } from 'fp-ts/lib/Either'
+ *
+ * assert.deepStrictEqual(ArrayFromString(NumberFromString, ",").decode("1,2,3"), right([1,2,3]))
+ * assert.deepStrictEqual(ArrayFromString(NumberFromString, /[\s,]+/).decode("1, 2, 3"), right([1,2,3]))
+ * @since 0.5.17
+ */
+export function ArrayFromString<C extends t.Mixed>(
+  codec: C,
+  decoderSeparator: string | RegExp = '',
+  encoderSeparator = '',
+  name = `ArrayFromString<${codec.name}>`
+): ArrayFromStringC<C> {
+  return new t.Type<Array<t.TypeOf<C>>, string, unknown>(
+    name,
+    (u): u is Array<t.TypeOf<C>> => u instanceof Array && u.every(codec.is),
+    (u, c) =>
+      pipe(
+        t.string.validate(u, c),
+        chain((str: string) =>
+          pipe(
+            str.split(decoderSeparator),
+            map(codec.decode),
+            Traversable.sequence(Applicative)
+          )
+        ),
+        chain(t.success)
+      ),
+    (a: Array<t.TypeOf<C>>) => map(codec.encode)(a).join(encoderSeparator)
+  )
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -147,3 +147,8 @@ export * from './withEncode'
  * @since 0.5.13
  */
 export * from './BooleanFromNumber'
+
+/**
+ * @since 0.5.17
+ */
+export * from './ArrayFromString'

--- a/test/ArrayFromString.ts
+++ b/test/ArrayFromString.ts
@@ -18,9 +18,12 @@ describe('ArrayFromString', () => {
     assertSuccess(T.decode('1,2,3'), [1, 2, 3])
     assertSuccess(T.decode('1, 2, 3'), [1, 2, 3])
     assertFailure(T, 1, ['Invalid value 1 supplied to : ArrayFromString<NumberFromString>'])
-    assertFailure(T, 'a', ['Invalid value "a" supplied to : NumberFromString'])
-    assertFailure(T, '1,a', ['Invalid value "a" supplied to : NumberFromString'])
-    assertFailure(T, '[1,2]', ['Invalid value "[1" supplied to : NumberFromString'])
+    assertFailure(T, 'a', ['Invalid value "a" supplied to : ArrayFromString<NumberFromString>/0: NumberFromString'])
+    assertFailure(T, '1,a', ['Invalid value "a" supplied to : ArrayFromString<NumberFromString>/1: NumberFromString'])
+    assertFailure(T, '[1,2]', [
+      'Invalid value "[1" supplied to : ArrayFromString<NumberFromString>/0: NumberFromString',
+      'Invalid value "2]" supplied to : ArrayFromString<NumberFromString>/1: NumberFromString'
+    ])
   })
   it('encode', () => {
     const T = ArrayFromString(NumberFromString)

--- a/test/ArrayFromString.ts
+++ b/test/ArrayFromString.ts
@@ -1,0 +1,32 @@
+import * as assert from 'assert'
+import { ArrayFromString, NumberFromString } from '../src'
+import { assertSuccess, assertFailure } from './helpers'
+
+describe('ArrayFromString', () => {
+  it('name', () => {
+    const T = ArrayFromString(NumberFromString, undefined, undefined, 'T')
+    assert.strictEqual(T.name, 'T')
+  })
+  it('is', () => {
+    const T = ArrayFromString(NumberFromString)
+    assert.strictEqual(T.is([1, 2]), true)
+    assert.strictEqual(T.is(['1', 2]), false)
+    assert.strictEqual(T.is('1,2'), false)
+  })
+  it('decode', () => {
+    const T = ArrayFromString(NumberFromString, /[\s,]+/)
+    assertSuccess(T.decode('1,2,3'), [1, 2, 3])
+    assertSuccess(T.decode('1, 2, 3'), [1, 2, 3])
+    assertFailure(T, 1, ['Invalid value 1 supplied to : ArrayFromString<NumberFromString>'])
+    assertFailure(T, 'a', ['Invalid value "a" supplied to : NumberFromString'])
+    assertFailure(T, '1,a', ['Invalid value "a" supplied to : NumberFromString'])
+    assertFailure(T, '[1,2]', ['Invalid value "[1" supplied to : NumberFromString'])
+  })
+  it('encode', () => {
+    const T = ArrayFromString(NumberFromString)
+    assert.strictEqual(T.encode([1, 2, 3]), '123')
+
+    const T2 = ArrayFromString(NumberFromString, undefined, '+')
+    assert.strictEqual(T2.encode([1, 2, 3]), '1+2+3')
+  })
+})


### PR DESCRIPTION
Generalised implementation of converting string to Array<T>. It is essentially utilising string.split and decoder for each item. It accepts both string and RegExp as split separator. It is compatible with other codecs, thus usage like `ArrayFromString(IntFromString)` is accepted