### PR TITLE
Add output indexed types to option and either

### DIFF
--- a/docs/modules/either.ts.md
+++ b/docs/modules/either.ts.md
@@ -13,6 +13,9 @@ Added in v0.5.0
 <h2 class="text-delta">Table of contents</h2>
 
 - [EitherC (interface)](#eitherc-interface)
+- [EitherOutput (type alias)](#eitheroutput-type-alias)
+- [LeftOutput (type alias)](#leftoutput-type-alias)
+- [RightOutput (type alias)](#rightoutput-type-alias)
 - [either](#either)
 
 ---
@@ -23,10 +26,40 @@ Added in v0.5.0
 
 ```ts
 export interface EitherC<L extends t.Mixed, R extends t.Mixed>
-  extends t.Type<Either<t.TypeOf<L>, t.TypeOf<R>>, Either<t.OutputOf<L>, t.OutputOf<R>>, unknown> {}
+  extends t.Type<Either<t.TypeOf<L>, t.TypeOf<R>>, EitherOutput<t.OutputOf<L>, t.OutputOf<R>>, unknown> {}
 ```
 
 Added in v0.5.0
+
+# EitherOutput (type alias)
+
+**Signature**
+
+```ts
+export type EitherOutput<L, R> = LeftOutput<L> | RightOutput<R>
+```
+
+Added in v0.5.18
+
+# LeftOutput (type alias)
+
+**Signature**
+
+```ts
+export type LeftOutput<L> = { _tag: 'Left'; left: L }
+```
+
+Added in v0.5.18
+
+# RightOutput (type alias)
+
+**Signature**
+
+```ts
+export type RightOutput<R> = { _tag: 'Right'; right: R }
+```
+
+Added in v0.5.18
 
 # either
 

--- a/docs/modules/option.ts.md
+++ b/docs/modules/option.ts.md
@@ -13,6 +13,9 @@ Added in v0.5.0
 <h2 class="text-delta">Table of contents</h2>
 
 - [OptionC (interface)](#optionc-interface)
+- [NoneOutput (type alias)](#noneoutput-type-alias)
+- [OptionOutput (type alias)](#optionoutput-type-alias)
+- [SomeOutput (type alias)](#someoutput-type-alias)
 - [option](#option)
 
 ---
@@ -25,7 +28,7 @@ the JSON representation of an `Option`.
 **Signature**
 
 ```ts
-export interface OptionC<C extends t.Mixed> extends t.Type<Option<t.TypeOf<C>>, Option<t.OutputOf<C>>, unknown> {}
+export interface OptionC<C extends t.Mixed> extends t.Type<Option<t.TypeOf<C>>, OptionOutput<t.OutputOf<C>>, unknown> {}
 ```
 
 **Example**
@@ -47,6 +50,36 @@ assert.deepStrictEqual(PathReporter.report(T.decode(some('a'))), [
 ```
 
 Added in v0.5.0
+
+# NoneOutput (type alias)
+
+**Signature**
+
+```ts
+export type NoneOutput = t.OutputOf<typeof None>
+```
+
+Added in v0.5.18
+
+# OptionOutput (type alias)
+
+**Signature**
+
+```ts
+export type OptionOutput<A> = NoneOutput | SomeOutput<A>
+```
+
+Added in v0.5.18
+
+# SomeOutput (type alias)
+
+**Signature**
+
+```ts
+export type SomeOutput<A> = { _tag: 'Some'; value: A }
+```
+
+Added in v0.5.18
 
 # option
 

--- a/dtslint/ts3.5/index.ts
+++ b/dtslint/ts3.5/index.ts
@@ -8,7 +8,7 @@ import { either, nonEmptyArray, NumberFromString, option, optionFromNullable, se
 
 const E = either(t.string, NumberFromString)
 type EA = t.TypeOf<typeof E> // $ExpectType Either<string, number>
-type EO = t.OutputOf<typeof E> // $ExpectType Either<string, string>
+type EO = t.OutputOf<typeof E> // $ExpectType EitherOutput<string, string>
 
 //
 // nonEmptyArray
@@ -26,7 +26,7 @@ nonEmptyArray(t.unknown).pipe(nonEmptyArray(t.unknown))
 
 const O = option(NumberFromString)
 type OA = t.TypeOf<typeof O> // $ExpectType Option<number>
-type OO = t.OutputOf<typeof O> // $ExpectType Option<string>
+type OO = t.OutputOf<typeof O> // $ExpectType OptionOutput<string>
 
 //
 // optionFromNullable

--- a/dtslint/ts3.5/index.ts
+++ b/dtslint/ts3.5/index.ts
@@ -1,6 +1,6 @@
 import { ordNumber } from 'fp-ts/lib/Ord'
 import * as t from 'io-ts'
-import { either, nonEmptyArray, NumberFromString, option, optionFromNullable, setFromArray } from '../../src'
+import { either, nonEmptyArray, NumberFromString, option, optionFromNullable, setFromArray, Json } from '../../src'
 
 //
 // either
@@ -43,3 +43,9 @@ type OFNO = t.OutputOf<typeof OFN> // $ExpectType string | null
 const SFA = setFromArray(NumberFromString, ordNumber)
 type SFAA = t.TypeOf<typeof SFA> // $ExpectType Set<number>
 type SFAO = t.OutputOf<typeof SFA> // $ExpectType string[]
+
+//
+// Json.pipe
+//
+const JO = Json.pipe(option(t.string)) // $ExpectType Type<Option<string>, Json, unknown>
+const JE = Json.pipe(either(t.string, t.number)) // $ExpectType Type<Either<string, number>, Json, unknown>

--- a/src/either.ts
+++ b/src/either.ts
@@ -1,18 +1,33 @@
 /**
  * @since 0.5.0
  */
-import * as t from 'io-ts'
 import { Either } from 'fp-ts/lib/Either'
+import * as t from 'io-ts'
 
 const leftLiteral = t.literal('Left')
 
 const rightLiteral = t.literal('Right')
 
 /**
+ * @since 0.5.18
+ */
+export type LeftOutput<L> = { _tag: 'Left'; left: L }
+
+/**
+ * @since 0.5.18
+ */
+export type RightOutput<R> = { _tag: 'Right'; right: R }
+
+/**
+ * @since 0.5.18
+ */
+export type EitherOutput<L, R> = LeftOutput<L> | RightOutput<R>
+
+/**
  * @since 0.5.0
  */
 export interface EitherC<L extends t.Mixed, R extends t.Mixed>
-  extends t.Type<Either<t.TypeOf<L>, t.TypeOf<R>>, Either<t.OutputOf<L>, t.OutputOf<R>>, unknown> {}
+  extends t.Type<Either<t.TypeOf<L>, t.TypeOf<R>>, EitherOutput<t.OutputOf<L>, t.OutputOf<R>>, unknown> {}
 
 /**
  * Given a codec representing a type `L` and a codec representing a type `A`, returns a codec representing `Either<L, A>` that is able to deserialize

--- a/src/option.ts
+++ b/src/option.ts
@@ -4,9 +4,12 @@
 import { Option } from 'fp-ts/lib/Option'
 import * as t from 'io-ts'
 
-const None = t.strict({
-  _tag: t.literal('None')
-})
+const None = t.strict(
+  {
+    _tag: t.literal('None')
+  },
+  'None'
+)
 
 const someLiteral = t.literal('Some')
 

--- a/src/option.ts
+++ b/src/option.ts
@@ -1,14 +1,29 @@
 /**
  * @since 0.5.0
  */
-import * as t from 'io-ts'
 import { Option } from 'fp-ts/lib/Option'
+import * as t from 'io-ts'
 
 const None = t.strict({
   _tag: t.literal('None')
 })
 
 const someLiteral = t.literal('Some')
+
+/**
+ * @since 0.5.18
+ */
+export type NoneOutput = t.OutputOf<typeof None>
+
+/**
+ * @since 0.5.18
+ */
+export type SomeOutput<A> = { _tag: 'Some'; value: A }
+
+/**
+ * @since 0.5.18
+ */
+export type OptionOutput<A> = NoneOutput | SomeOutput<A>
 
 /**
  * Given a codec representing a type `A`, returns a codec representing `Option<A>` that is able to deserialize
@@ -29,7 +44,7 @@ const someLiteral = t.literal('Some')
  *
  * @since 0.5.0
  */
-export interface OptionC<C extends t.Mixed> extends t.Type<Option<t.TypeOf<C>>, Option<t.OutputOf<C>>, unknown> {}
+export interface OptionC<C extends t.Mixed> extends t.Type<Option<t.TypeOf<C>>, OptionOutput<t.OutputOf<C>>, unknown> {}
 
 /**
  * @since 0.5.0


### PR DESCRIPTION
This PR adds indexed output types to the `option` and `either` codecs. This solves the problem that it is currently not possible to do `Json.pipe(option(t.unknown))` or `Json.pipe(either(t.string, t.unknown))` as the `fp-ts` types can not be assigned to `JsonRecord`. As we don't want to loose the `interface` representation in `fp-ts` it is the best to add an indexed version to `io-ts-types`.

This is related to https://github.com/gcanti/fp-ts/issues/1734