### PR TITLE
Set sourceMap to false in 0.4.x branch

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "outDir": "./lib",
-    "sourceMap": true,
+    "sourceMap": false,
     "declaration": true,
     "module": "commonjs",
     "strict": true,


### PR DESCRIPTION

In tsconfig.json, sourceMap is set to true, but sources are not published. This was resolved in https://github.com/gcanti/io-ts-types/issues/106 for the 0.5.x branch. This is the same fix for the 0.4.x branch.
