### PR TITLE
Add new test to DateFromISOString codec

### DIFF
--- a/test/DateFromISOString.ts
+++ b/test/DateFromISOString.ts
@@ -1,6 +1,6 @@
 import * as assert from 'assert'
 import { DateFromISOString } from '../src'
-import { assertSuccess, assertFailure } from './helpers'
+import { assertFailure, assertSuccess } from './helpers'
 
 const d = new Date(1973, 10, 30)
 const s = d.toISOString()
@@ -16,6 +16,7 @@ describe('DateFromISOString', () => {
     assertSuccess(T.decode(s), d)
     assertFailure(T, null, ['Invalid value null supplied to : DateFromISOString'])
     assertFailure(T, 'foo', ['Invalid value "foo" supplied to : DateFromISOString'])
+    assert.deepStrictEqual(T.decode(d)._tag, 'Left')
   })
 
   it('encode', () => {


### PR DESCRIPTION
Add test to cover `new Date()` passed as argument to `DateFromISOString` `decode` function.