### PR TITLE
feat: Add BufferFromBase64 codec

### DIFF
--- a/docs/modules/BufferFromBase64.ts.md
+++ b/docs/modules/BufferFromBase64.ts.md
@@ -1,0 +1,48 @@
+---
+title: BufferFromBase64.ts
+nav_order: 4
+parent: Modules
+---
+
+# BufferFromBase64 overview
+
+Added in v0.5.19
+
+---
+
+<h2 class="text-delta">Table of contents</h2>
+
+- [BufferFromBase64C (interface)](#bufferfrombase64c-interface)
+- [BufferFromBase64](#bufferfrombase64)
+
+---
+
+# BufferFromBase64C (interface)
+
+**Signature**
+
+```ts
+export interface BufferFromBase64C extends t.Type<Buffer, string, unknown> {}
+```
+
+Added in v0.5.19
+
+# BufferFromBase64
+
+**Signature**
+
+```ts
+export const BufferFromBase64: BufferFromBase64C = ...
+```
+
+**Example**
+
+```ts
+import { BufferFromBase64 } from 'io-ts-types/lib/BufferFromBase64'
+import { right } from 'fp-ts/lib/Either'
+
+const base64String = 'dGVzdCBvZiB0aGUgY29kZWM='
+assert.deepStrictEqual(BufferFromBase64.decode(base64String), right(Buffer.from('test of the codec')))
+```
+
+Added in v0.5.19

--- a/docs/modules/DateFromISOString.ts.md
+++ b/docs/modules/DateFromISOString.ts.md
@@ -1,6 +1,6 @@
 ---
 title: DateFromISOString.ts
-nav_order: 6
+nav_order: 7
 parent: Modules
 ---
 

--- a/docs/modules/DateFromNumber.ts.md
+++ b/docs/modules/DateFromNumber.ts.md
@@ -1,6 +1,6 @@
 ---
 title: DateFromNumber.ts
-nav_order: 7
+nav_order: 8
 parent: Modules
 ---
 

--- a/docs/modules/DateFromUnixTime.ts.md
+++ b/docs/modules/DateFromUnixTime.ts.md
@@ -1,6 +1,6 @@
 ---
 title: DateFromUnixTime.ts
-nav_order: 8
+nav_order: 9
 parent: Modules
 ---
 

--- a/docs/modules/IntFromString.ts.md
+++ b/docs/modules/IntFromString.ts.md
@@ -1,6 +1,6 @@
 ---
 title: IntFromString.ts
-nav_order: 15
+nav_order: 16
 parent: Modules
 ---
 

--- a/docs/modules/JsonFromString.ts.md
+++ b/docs/modules/JsonFromString.ts.md
@@ -1,6 +1,6 @@
 ---
 title: JsonFromString.ts
-nav_order: 16
+nav_order: 17
 parent: Modules
 ---
 

--- a/docs/modules/NonEmptyString.ts.md
+++ b/docs/modules/NonEmptyString.ts.md
@@ -1,6 +1,6 @@
 ---
 title: NonEmptyString.ts
-nav_order: 20
+nav_order: 21
 parent: Modules
 ---
 

--- a/docs/modules/NumberFromString.ts.md
+++ b/docs/modules/NumberFromString.ts.md
@@ -1,6 +1,6 @@
 ---
 title: NumberFromString.ts
-nav_order: 21
+nav_order: 22
 parent: Modules
 ---
 

--- a/docs/modules/UUID.ts.md
+++ b/docs/modules/UUID.ts.md
@@ -1,6 +1,6 @@
 ---
 title: UUID.ts
-nav_order: 29
+nav_order: 30
 parent: Modules
 ---
 

--- a/docs/modules/clone.ts.md
+++ b/docs/modules/clone.ts.md
@@ -1,6 +1,6 @@
 ---
 title: clone.ts
-nav_order: 4
+nav_order: 5
 parent: Modules
 ---
 

--- a/docs/modules/date.ts.md
+++ b/docs/modules/date.ts.md
@@ -1,6 +1,6 @@
 ---
 title: date.ts
-nav_order: 5
+nav_order: 6
 parent: Modules
 ---
 

--- a/docs/modules/either.ts.md
+++ b/docs/modules/either.ts.md
@@ -1,6 +1,6 @@
 ---
 title: either.ts
-nav_order: 9
+nav_order: 10
 parent: Modules
 ---
 

--- a/docs/modules/fromNewtype.ts.md
+++ b/docs/modules/fromNewtype.ts.md
@@ -1,6 +1,6 @@
 ---
 title: fromNewtype.ts
-nav_order: 10
+nav_order: 11
 parent: Modules
 ---
 

--- a/docs/modules/fromNullable.ts.md
+++ b/docs/modules/fromNullable.ts.md
@@ -1,6 +1,6 @@
 ---
 title: fromNullable.ts
-nav_order: 11
+nav_order: 12
 parent: Modules
 ---
 

--- a/docs/modules/fromRefinement.ts.md
+++ b/docs/modules/fromRefinement.ts.md
@@ -1,6 +1,6 @@
 ---
 title: fromRefinement.ts
-nav_order: 12
+nav_order: 13
 parent: Modules
 ---
 

--- a/docs/modules/getLenses.ts.md
+++ b/docs/modules/getLenses.ts.md
@@ -1,6 +1,6 @@
 ---
 title: getLenses.ts
-nav_order: 13
+nav_order: 14
 parent: Modules
 ---
 

--- a/docs/modules/index.ts.md
+++ b/docs/modules/index.ts.md
@@ -1,6 +1,6 @@
 ---
 title: index.ts
-nav_order: 14
+nav_order: 15
 parent: Modules
 ---
 

--- a/docs/modules/mapFromEntries.ts.md
+++ b/docs/modules/mapFromEntries.ts.md
@@ -1,6 +1,6 @@
 ---
 title: mapFromEntries.ts
-nav_order: 17
+nav_order: 18
 parent: Modules
 ---
 

--- a/docs/modules/mapOutput.ts.md
+++ b/docs/modules/mapOutput.ts.md
@@ -1,6 +1,6 @@
 ---
 title: mapOutput.ts
-nav_order: 18
+nav_order: 19
 parent: Modules
 ---
 

--- a/docs/modules/nonEmptyArray.ts.md
+++ b/docs/modules/nonEmptyArray.ts.md
@@ -1,6 +1,6 @@
 ---
 title: nonEmptyArray.ts
-nav_order: 19
+nav_order: 20
 parent: Modules
 ---
 

--- a/docs/modules/option.ts.md
+++ b/docs/modules/option.ts.md
@@ -1,6 +1,6 @@
 ---
 title: option.ts
-nav_order: 22
+nav_order: 23
 parent: Modules
 ---
 

--- a/docs/modules/optionFromNullable.ts.md
+++ b/docs/modules/optionFromNullable.ts.md
@@ -1,6 +1,6 @@
 ---
 title: optionFromNullable.ts
-nav_order: 23
+nav_order: 24
 parent: Modules
 ---
 

--- a/docs/modules/readonlyMapFromEntries.ts.md
+++ b/docs/modules/readonlyMapFromEntries.ts.md
@@ -1,6 +1,6 @@
 ---
 title: readonlyMapFromEntries.ts
-nav_order: 24
+nav_order: 25
 parent: Modules
 ---
 

--- a/docs/modules/readonlyNonEmptyArray.ts.md
+++ b/docs/modules/readonlyNonEmptyArray.ts.md
@@ -1,6 +1,6 @@
 ---
 title: readonlyNonEmptyArray.ts
-nav_order: 25
+nav_order: 26
 parent: Modules
 ---
 

--- a/docs/modules/readonlySetFromArray.ts.md
+++ b/docs/modules/readonlySetFromArray.ts.md
@@ -1,6 +1,6 @@
 ---
 title: readonlySetFromArray.ts
-nav_order: 26
+nav_order: 27
 parent: Modules
 ---
 

--- a/docs/modules/regexp.ts.md
+++ b/docs/modules/regexp.ts.md
@@ -1,6 +1,6 @@
 ---
 title: regexp.ts
-nav_order: 27
+nav_order: 28
 parent: Modules
 ---
 

--- a/docs/modules/setFromArray.ts.md
+++ b/docs/modules/setFromArray.ts.md
@@ -1,6 +1,6 @@
 ---
 title: setFromArray.ts
-nav_order: 28
+nav_order: 29
 parent: Modules
 ---
 

--- a/docs/modules/withEncode.ts.md
+++ b/docs/modules/withEncode.ts.md
@@ -1,6 +1,6 @@
 ---
 title: withEncode.ts
-nav_order: 30
+nav_order: 31
 parent: Modules
 ---
 

--- a/docs/modules/withFallback.ts.md
+++ b/docs/modules/withFallback.ts.md
@@ -1,6 +1,6 @@
 ---
 title: withFallback.ts
-nav_order: 31
+nav_order: 32
 parent: Modules
 ---
 

--- a/docs/modules/withMessage.ts.md
+++ b/docs/modules/withMessage.ts.md
@@ -1,6 +1,6 @@
 ---
 title: withMessage.ts
-nav_order: 32
+nav_order: 33
 parent: Modules
 ---
 

--- a/docs/modules/withValidate.ts.md
+++ b/docs/modules/withValidate.ts.md
@@ -1,6 +1,6 @@
 ---
 title: withValidate.ts
-nav_order: 33
+nav_order: 34
 parent: Modules
 ---
 

--- a/src/BufferFromBase64.ts
+++ b/src/BufferFromBase64.ts
@@ -1,0 +1,34 @@
+/**
+ * @since 0.5.19
+ */
+import * as t from 'io-ts'
+import { pipe } from 'fp-ts/lib/pipeable'
+import { chain } from 'fp-ts/lib/Either'
+
+const base64RegExp = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/
+
+/**
+ * @since 0.5.19
+ */
+export interface BufferFromBase64C extends t.Type<Buffer, string, unknown> {}
+
+/**
+ * @example
+ * import { BufferFromBase64 } from 'io-ts-types/lib/BufferFromBase64'
+ * import { right } from 'fp-ts/lib/Either'
+ *
+ * const base64String = 'dGVzdCBvZiB0aGUgY29kZWM='
+ * assert.deepStrictEqual(BufferFromBase64.decode(base64String), right(Buffer.from('test of the codec')))
+ *
+ * @since 0.5.19
+ */
+export const BufferFromBase64: BufferFromBase64C = new t.Type<Buffer, string, unknown>(
+  'BufferFromBase64',
+  (u): u is Buffer => Buffer.isBuffer(u),
+  (u, c) =>
+    pipe(
+      t.string.validate(u, c),
+      chain(s => (base64RegExp.test(s) ? t.success(Buffer.from(s, 'base64')) : t.failure(u, c)))
+    ),
+  b => b.toString('base64')
+)

--- a/test/BufferFromBase64.ts
+++ b/test/BufferFromBase64.ts
@@ -1,0 +1,39 @@
+import * as assert from 'assert'
+import { assertFailure, assertStrictEqual } from './helpers'
+import { BufferFromBase64 } from '../src/BufferFromBase64'
+
+describe.only('BufferFromBase64', () => {
+  it('is', () => {
+    const T = BufferFromBase64
+    assert.strictEqual(T.is(Buffer.from('string')), true)
+    assert.strictEqual(T.is(Buffer.alloc(0)), true)
+    assert.strictEqual(T.is(null), false)
+    assert.strictEqual(T.is(undefined), false)
+    assert.strictEqual(T.is('string'), false)
+    assert.strictEqual(T.is('SGVsbG8gV29ybGQ='), false)
+    assert.strictEqual(T.is(3), false)
+    assert.strictEqual(T.is({ a: null }), false)
+    assert.strictEqual(T.is([]), false)
+  })
+  it('decode', () => {
+    const T = BufferFromBase64
+    assertStrictEqual(T.decode('SGVsbG8gV29ybGQ='), Buffer.from('SGVsbG8gV29ybGQ=', 'base64'))
+    assertStrictEqual(T.decode('MQ=='), Buffer.from('MQ==', 'base64'))
+    assertStrictEqual(T.decode(Buffer.from('').toString('base64')), Buffer.from('', 'base64'))
+    assertFailure(T, 'notBase64', ['Invalid value "notBase64" supplied to : BufferFromBase64'])
+    assertFailure(T, 'SGVsbG8gV29ybGQ==', ['Invalid value "SGVsbG8gV29ybGQ==" supplied to : BufferFromBase64'])
+    assertFailure(T, 3, ['Invalid value 3 supplied to : BufferFromBase64'])
+    assertFailure(T, null, ['Invalid value null supplied to : BufferFromBase64'])
+    assertFailure(T, undefined, ['Invalid value undefined supplied to : BufferFromBase64'])
+    assertFailure(T, ' ', ['Invalid value " " supplied to : BufferFromBase64'])
+    assertFailure(T, { a: null }, ['Invalid value {"a":null} supplied to : BufferFromBase64'])
+    assertFailure(T, [], ['Invalid value [] supplied to : BufferFromBase64'])
+    assertFailure(T, Buffer.from('s'), ['Invalid value {"type":"Buffer","data":[115]} supplied to : BufferFromBase64'])
+  })
+  it('encode', () => {
+    const T = BufferFromBase64
+    assert.strictEqual(T.encode(Buffer.from('')), '')
+    assert.strictEqual(T.encode(Buffer.from('string')), 'c3RyaW5n')
+    assert.strictEqual(T.encode(Buffer.from('1')), 'MQ==')
+  })
+})


### PR DESCRIPTION
I propose to add this codec. It is useful when you have a base64 string from external of your domain. 
In this case, mainly if the string is long, it is very useful to use a Buffer instead of a string for at least two reasons: 
* if you have a base64 string and you move it within your domain, you copy the string many times, instead with Buffer you have a reference to pass between applications; 
* in this way you already parse a base64 string and you are sure that Buffer contains a valid array of bytes. Of course, you cannot be sure of the correctness of the contents, but you are sure of the correctness of the base64 string.

```ts
import { BufferFromBase64 } from 'io-ts-types/lib/BufferFromBase64'
import { right } from 'fp-ts/lib/Either'

const base64String = 'dGVzdCBvZiB0aGUgY29kZWM='
assert.deepStrictEqual(BufferFromBase64.decode(base64String), right(Buffer.from('test of the codec')))
```
